### PR TITLE
extracts an IAuthorizeMint interface from Mintpass

### DIFF
--- a/script/Dev.s.sol
+++ b/script/Dev.s.sol
@@ -25,7 +25,7 @@ contract DevScript is Script {
         Mintpass mintpass = new Mintpass(address(ipnft));
         mintpass.grantRole(mintpass.MODERATOR(), deployer);
 
-        ipnft.setMintpassContract(address(mintpass));
+        ipnft.setAuthorizer(address(mintpass));
 
         console.log("ipnftv2 %s", address(ipnft));
         console.log("swap %s", address(swap));

--- a/script/Fixture.s.sol
+++ b/script/Fixture.s.sol
@@ -76,7 +76,7 @@ contract FixtureScript is Script {
         mintpass = new Mintpass(address(ipnft));
         mintpass.grantRole(mintpass.MODERATOR(), deployer);
 
-        ipnft.setMintpassContract(address(mintpass));
+        ipnft.setAuthorizer(address(mintpass));
 
         console.log("ipnftv2 %s", address(ipnft));
         console.log("swap %s", address(schmackoSwap));

--- a/src/IAuthorizeMints.sol
+++ b/src/IAuthorizeMints.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+interface IAuthorizeMints {
+    function authorizeMint(address minter, address to, bytes memory data) external view returns (bool);
+    function authorizeReservation(address reserver) external view returns (bool);
+    function redeem(bytes memory data) external;
+}

--- a/test/IPNFT.t.js
+++ b/test/IPNFT.t.js
@@ -18,7 +18,7 @@ describe("IPNFT fundamentals", function () {
     const Mintpass = await ethers.getContractFactory("Mintpass");
     mintpass = await Mintpass.deploy(ipnftContract.address);
 
-    await (ipnftContract.connect(deployer)).setMintpassContract(mintpass.address);
+    await (ipnftContract.connect(deployer)).setAuthorizer(mintpass.address);
   });
 
 

--- a/test/IPNFT.t.sol
+++ b/test/IPNFT.t.sol
@@ -39,7 +39,7 @@ contract IPNFTTest is IPNFTMintHelper {
 
         mintpass = new Mintpass(address(ipnft));
         mintpass.grantRole(mintpass.MODERATOR(), deployer);
-        ipnft.setMintpassContract(address(mintpass));
+        ipnft.setAuthorizer(address(mintpass));
         vm.stopPrank();
     }
 

--- a/test/SchmackoSwap.t.sol
+++ b/test/SchmackoSwap.t.sol
@@ -51,7 +51,7 @@ contract SchmackoSwapTest is Test {
 
         mintpass = new Mintpass(address(ipnft));
         mintpass.grantRole(mintpass.MODERATOR(), deployer);
-        ipnft.setMintpassContract(address(mintpass));
+        ipnft.setAuthorizer(address(mintpass));
         mintpass.batchMint(seller, 1);
 
         TestToken _testToken = new TestToken();

--- a/test/ipnft.gas.js
+++ b/test/ipnft.gas.js
@@ -35,7 +35,7 @@ describe("IPNFT1155 gas usage", function () {
 
     const Mintpass = await ethers.getContractFactory("Mintpass");
     mintpass = await Mintpass.deploy(ipnftContract.address);
-    await (ipnftContract.connect(deployer)).setMintpassContract(mintpass.address);
+    await (ipnftContract.connect(deployer)).setAuthorizer(mintpass.address);
     await mintpass
       .connect(deployer)
       .grantRole(await mintpass.MODERATOR(), deployer.address);


### PR DESCRIPTION
this lets us very easily and safely replace mint allowance functionality without changing the IPFNT contract security: fixes the "to" allowance in mintpass (the minter shall be allowed, not the recipient)

Signed-off-by: Stefan Adolf <stefan@molecule.to>