### PR TITLE
Contract guard that checks whether a user is a member of a holding multisig

### DIFF
--- a/src/CollectiveAccessGuard.sol
+++ b/src/CollectiveAccessGuard.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import { IERC1155 } from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+
+/// @title Collective Access Guard
+/// @author molecule.to
+/// @notice Tries to check whether an address either owns a single 1155 asset or
+contract CollectiveAccessGuard {
+    bytes32 private constant DOMAIN_SEPARATOR_TYPEHASH = 0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218;
+
+    /// @dev Returns the chain id used by this contract.
+    function getChainId() public view returns (uint256) {
+        uint256 id;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            id := chainid()
+        }
+        return id;
+    }
+
+    function isContract(address _addr) internal view returns (bool) {
+        return _addr.code.length > 0;
+    }
+
+    function isLikelyGSafe(address _addr) internal returns (bool) {
+        if (!isContract(_addr)) {
+            return false;
+        }
+        (bool success, bytes memory separatorResult) = _addr.call{gas: 5000}(abi.encodeWithSignature("domainSeparator()"));
+        if (!success) return false;
+
+        bytes32 _theirDomainSeparator = abi.decode(separatorResult, (bytes32));
+        bytes32 _ourDomainSeparator = keccak256(abi.encode(DOMAIN_SEPARATOR_TYPEHASH, getChainId(), _addr));
+        return (_theirDomainSeparator == _ourDomainSeparator);
+    }
+
+    function checkIfCallerIsMemberOfSafe(address safe, address caller) internal returns (bool) {
+        (bool success, bytes memory ownerResult) = safe.call{gas: 10000}(abi.encodeWithSignature("isOwner(address)", caller));
+        if (!success) return false;
+        bool isOwner = abi.decode(ownerResult, (bool));
+        return isOwner;
+    }
+
+    /**
+     * @param erc1155 can be an ERC1155 or a contract that exposes an `ownerOf` method, e.g. an extended ERC1155 or a default ERC721 contract
+     * @param tokenId token id
+     * @param member the address to check ownership for
+     */
+    function canAccessContent(IERC1155 erc1155, uint256 tokenId, address member) public returns (bool) {
+        try erc1155.balanceOf(member, tokenId) returns (uint256 balance) {
+            if (balance > 0) return true;
+        } catch (bytes memory) { }
+
+        address ownableContract = address(erc1155);
+        (bool success, bytes memory ownerResult_) = ownableContract.call{gas: 5000}(abi.encodeWithSignature("ownerOf(uint256)", tokenId));
+        if (!success) {
+            return false;
+        }
+
+        address owner = abi.decode(ownerResult_, (address));
+        if (erc1155.balanceOf(owner, tokenId) == 0) {
+            return false;
+        }
+
+        if (!isLikelyGSafe(owner)) {
+            return false;
+        }
+
+        if (!checkIfCallerIsMemberOfSafe(owner, member)) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/IPNFT.sol
+++ b/src/IPNFT.sol
@@ -51,6 +51,9 @@ contract IPNFT is
     /// @notice e.g. a mintpass contract
     IAuthorizeMints mintAuthorizer;
 
+    ///@notice this only works for token ids with a supply of 1
+    mapping(uint256 => address) public ownerOf;
+
     /*
      *
      * EVENTS
@@ -180,6 +183,24 @@ contract IPNFT is
         override (ERC1155Upgradeable, ERC1155SupplyUpgradeable)
     {
         super._beforeTokenTransfer(operator, from, to, ids, amounts, data);
+    }
+
+    function _afterTokenTransfer(address operator, address from, address to, uint256[] memory ids, uint256[] memory amounts, bytes memory data)
+        internal
+        override (ERC1155Upgradeable)
+    {
+        super._afterTokenTransfer(operator, from, to, ids, amounts, data);
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            if (totalSupply(ids[i]) == 1 && amounts[i] == 1) {
+                ownerOf[ids[i]] = to;
+            } else {
+                //burnt
+                if (totalSupply(ids[i]) == 0) {
+                    ownerOf[ids[i]] = address(0);
+                }
+            }
+        }
     }
 
     /// @dev override required by Solidity.

--- a/test/IPNFT.t.sol
+++ b/test/IPNFT.t.sol
@@ -82,6 +82,7 @@ contract IPNFTTest is IPNFTMintHelper {
 
         vm.startPrank(alice);
         uint256 reservationId = ipnft.reserve();
+        assertEq(ipnft.ownerOf(1), address(0));
 
         vm.expectEmit(true, true, false, true);
         emit IPNFTMinted(alice, 1, ipfsUri);
@@ -91,7 +92,7 @@ contract IPNFTTest is IPNFTMintHelper {
         assertEq(ipnft.uri(1), ipfsUri);
 
         assertEq(ipnft.reservations(1), address(0));
-
+        assertEq(ipnft.ownerOf(1), alice);
         vm.stopPrank();
     }
 
@@ -103,6 +104,7 @@ contract IPNFTTest is IPNFTMintHelper {
         ipnft.burn(alice, tokenId, 1);
 
         assertEq(ipnft.balanceOf(alice, tokenId), 0);
+        assertEq(ipnft.ownerOf(tokenId), address(0));
     }
 
     function testOnlyReservationOwnerCanMintFromReservation() public {


### PR DESCRIPTION
CollectiveAccessGuard checks whether a user is a signer of a Gnosis Safe holding the asset 
adds an ownerOf counter for unique erc1155 assets
