### PR TITLE
uses strings to store the fam agreement cid

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,23 +21,22 @@ IP-NFTs allow their users to tokenize intellectual property. This repo contains 
 | Contract     | Address                                                                                                                            | Actions                                                                                                                                                                                                                                                                                               |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | IP-NFT       | [0x36444254795ce6E748cf0317EEE4c4271325D92A](https://goerli.etherscan.io/address/0x36444254795ce6E748cf0317EEE4c4271325D92A#code>) | <a href="https://thirdweb.com/goerli/0x36444254795ce6E748cf0317EEE4c4271325D92A?utm_source=contract_badge" target="_blank"><img width="200" height="45" src="https://badges.thirdweb.com/contract?address=0x36444254795ce6E748cf0317EEE4c4271325D92A&theme=dark&chainId=5" alt="View contract" /></a> |
-| SchmackoSwap | [0x2365BEDC04Fb449718D3143C88aF73ad83d7b9B6](https://goerli.etherscan.io/address/0x2365BEDC04Fb449718D3143C88aF73ad83d7b9B6#code)  | <a href="https://thirdweb.com/goerli/0x2365BEDC04Fb449718D3143C88aF73ad83d7b9B6?utm_source=contract_badge" target="_blank"><img width="200" height="45" src="https://badges.thirdweb.com/contract?address=0x2365BEDC04Fb449718D3143C88aF73ad83d7b9B6&theme=dark&chainId=5" alt="View contract" /></a> |
+| SchmackoSwap | [0x2b3e3F64bEe5E184981836d0599d51935d669701](https://goerli.etherscan.io/address/0x2b3e3F64bEe5E184981836d0599d51935d669701#code)  | <a href="https://thirdweb.com/goerli/0x2b3e3F64bEe5E184981836d0599d51935d669701?utm_source=contract_badge" target="_blank"><img width="200" height="45" src="https://badges.thirdweb.com/contract?address=0x2b3e3F64bEe5E184981836d0599d51935d669701&theme=dark&chainId=5" alt="View contract" /></a> |
 | Mintpass     | [0xaf0f99dcc64e8a6549d32013ac9f2c3fa7834688](https://goerli.etherscan.io/address/0xaf0f99dcc64e8a6549d32013ac9f2c3fa7834688#code)  | <a href="https://thirdweb.com/goerli/0xaf0f99dcc64e8a6549d32013ac9f2c3fa7834688?utm_source=contract_badge" target="_blank"><img width="200" height="45" src="https://badges.thirdweb.com/contract?address=0xaf0f99dcc64e8a6549d32013ac9f2c3fa7834688&theme=dark&chainId=5" alt="View contract" /></a> |
 
 - HeadlessDispenser <https://goerli.etherscan.io/address/0x0F1Bd197c5dCC6bC7E8025037a7780010E2Cd22A#code>
 - Subgraph: <https://api.thegraph.com/subgraphs/name/dorianwilhelm/ip-nft-subgraph-goerli/graphql>
-- Impl 2.2 0x026fa78c956ddf29fa84371460727bac0fd6204a
 
-- Contract Registry 0x91d6984adecadeb13f8bef2db8c4cb896210fcb1
-  https://goerli.etherscan.io/address/0x91d6984adecadeb13f8bef2db8c4cb896210fcb1#code
+- Contract Registry 0x3e36ce70fA445B22a694F039f1656529cC9b3189
+  https://goerli.etherscan.io/address/0x3e36ce70fA445B22a694F039f1656529cC9b3189#code
 
-- Fractionalizer Dispatcher L1: 0xB3bE2424FBc0A9cCb3FB5fFD5655235F21855526
-  (Impl no 7 0x305786450e56856fEd3A8764a24229AA9F8Adc4B)
-  <https://goerli.etherscan.io/address/0xB3bE2424FBc0A9cCb3FB5fFD5655235F21855526>
+- Fractionalizer Dispatcher L1: 0x1765b6823BAFa0DfF99bA05077C2b3642695152d
+  (Impl no 1 0x83b10a0868fc9c355152D6c202f89ce789Eeacb5)
+  <https://goerli.etherscan.io/address/0x1765b6823BAFa0DfF99bA05077C2b3642695152d>
 
-- Fractionalizer L2: 0x7DA77f8a834369dDc5e9e47407C9746Ed55C3b72
-  (Impl no 2 0xbD7F095b9002ED155eDA48B01eB2C683DdE6b3f3)
-  <https://goerli-optimism.etherscan.io/address/0x7DA77f8a834369dDc5e9e47407C9746Ed55C3b72>
+- Fractionalizer L2: 0x0803599ef1e4A479f5B7862994Af94178a1f74e4
+  (Impl no 1 0xf59afA90E10acaA16A5b2E2b9DB997A7d6018FdF)
+  <https://goerli-optimism.etherscan.io/address/0x0803599ef1e4A479f5B7862994Af94178a1f74e4>
 
 ## Prerequisites
 
@@ -156,7 +155,7 @@ Manual deployment order
   `NETWORK=5 forge script script/DeployContractRegistry.s.sol --rpc-url $RPC_URL_L1 --broadcast -vvvv`
 
 - deploy L1 dispatcher
-  `SOS_ADDRESS=<schmackoswapOnL1> REGISTRY_ADDRESS=<registry address> forge script script/DeployFractionalizerL1.s.sol --rpc-url $RPC_URL_1 --broadcast -vvvv`
+  `SOS_ADDRESS=<schmackoswapOnL1> REGISTRY_ADDRESS=<registry address> forge script script/DeployFractionalizerDispatcherL1.s.sol --rpc-url $RPC_URL_1 --broadcast -vvvv`
 
 - deploy L2 fractionalizer
   `forge script script/DeployFractionalizerL2.s.sol --rpc-url $RPC_URL_L2 --broadcast -vvvv`

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ IP-NFTs allow their users to tokenize intellectual property. This repo contains 
   <https://goerli.etherscan.io/address/0x1765b6823BAFa0DfF99bA05077C2b3642695152d>
 
 - Fractionalizer L2: 0x0803599ef1e4A479f5B7862994Af94178a1f74e4
-  (Impl no 1 0xf59afA90E10acaA16A5b2E2b9DB997A7d6018FdF)
+  (Impl no 2 0x423c4BC600EC07A74133D7D3a759D58539AB4A40)
   <https://goerli-optimism.etherscan.io/address/0x0803599ef1e4A479f5B7862994Af94178a1f74e4>
 
 ## Prerequisites

--- a/script/SchmackoSwap.s.sol
+++ b/script/SchmackoSwap.s.sol
@@ -10,7 +10,9 @@ contract SchmackoSwapScript is Script {
 
     function run() public {
         vm.startBroadcast();
-        new SchmackoSwap();
+        SchmackoSwap sos = new SchmackoSwap();
+
         vm.stopBroadcast();
+        console.log("Schmackoswap %s", address(sos));
     }
 }

--- a/script/dev/SignTermsMessage.s.sol
+++ b/script/dev/SignTermsMessage.s.sol
@@ -9,7 +9,7 @@ contract SignTermsMessage is Script {
     function run() public {
         uint256 pk = vm.envUint("PRIVATE_KEY");
         string memory terms =
-            "As a fraction holder of IPNFT #10, I accept all terms that I've read here: 0x616e2061677265656d656e742068617368000000000000000000000000000000\n\nChain Id: 31337\nVersion: 1";
+            "As a fraction holder of IPNFT #10, I accept all terms that I've read here: ipfs://bafkreigk5dvqblnkdniges6ft5kmuly47ebw4vho6siikzmkaovq6sjstq\n\nChain Id: 31337\nVersion: 1";
 
         bytes32 termsHash = ECDSA.toEthSignedMessageHash(abi.encodePacked(terms));
 

--- a/src/Fractionalizer.sol
+++ b/src/Fractionalizer.sol
@@ -105,14 +105,14 @@ contract Fractionalizer is ERC1155SupplyUpgradeable, UUPSUpgradeable, ERC2771Con
         emit FractionalizerChanged(_fractionalizerDispatcherOnL1);
     }
 
-    function setFeeReceiver(address _feeReceiver) public {
+    function setFeeReceiver(address _feeReceiver) public onlyOwner {
         if (_feeReceiver == address(0)) {
             revert ToZeroAddress();
         }
         feeReceiver = _feeReceiver;
     }
 
-    function setReceiverPercentage(uint256 _fractionalizationPercentage) external {
+    function setReceiverPercentage(uint256 _fractionalizationPercentage) external onlyOwner {
         fractionalizationPercentage = _fractionalizationPercentage;
     }
 

--- a/src/Fractionalizer.sol
+++ b/src/Fractionalizer.sol
@@ -26,7 +26,7 @@ struct Fractionalized {
     //needed to remember an individual's share after others burn their tokens
     uint256 totalIssued;
     address originalOwner;
-    bytes32 agreementHash;
+    string agreementCid;
     IERC20 paymentToken;
     uint256 paidPrice;
 }
@@ -43,7 +43,7 @@ contract Fractionalizer is ERC1155SupplyUpgradeable, UUPSUpgradeable, ERC2771Con
     using SafeERC20 for IERC20;
 
     event FractionsCreated(
-        address indexed collection, uint256 indexed tokenId, address emitter, uint256 indexed fractionId, uint256 amount, bytes32 agreementHash
+        address indexed collection, uint256 indexed tokenId, address emitter, uint256 indexed fractionId, uint256 amount, string agreementCid
     );
     event SalesActivated(uint256 fractionId, address paymentToken, uint256 paidPrice);
     event TermsAccepted(uint256 indexed fractionId, address indexed signer);
@@ -134,7 +134,7 @@ contract Fractionalizer is ERC1155SupplyUpgradeable, UUPSUpgradeable, ERC2771Con
         uint256 tokenId,
         address originalOwner,
         address recipient,
-        bytes32 agreementHash,
+        string calldata agreementCid,
         uint256 fractionsAmount
     ) public onlyXDomain onlyDispatcher {
         if (uint256(keccak256(abi.encodePacked(originalOwner, collection, tokenId))) != fractionId) {
@@ -146,11 +146,11 @@ contract Fractionalizer is ERC1155SupplyUpgradeable, UUPSUpgradeable, ERC2771Con
             revert("token is already fractionalized");
         }
 
-        fractionalized[fractionId] = Fractionalized(collection, tokenId, fractionsAmount, originalOwner, agreementHash, IERC20(address(0)), 0);
+        fractionalized[fractionId] = Fractionalized(collection, tokenId, fractionsAmount, originalOwner, agreementCid, IERC20(address(0)), 0);
 
         _mint(recipient, fractionId, fractionsAmount, "");
         //todo: if we want to take a protocol fee, this might be agood point of doing so.
-        emit FractionsCreated(collection, tokenId, originalOwner, fractionId, fractionsAmount, agreementHash);
+        emit FractionsCreated(collection, tokenId, originalOwner, fractionId, fractionsAmount, agreementCid);
     }
 
     //todo: the original owner (L1) might not have access to his own account on L2 (multisig)
@@ -225,8 +225,8 @@ contract Fractionalizer is ERC1155SupplyUpgradeable, UUPSUpgradeable, ERC2771Con
             abi.encodePacked(
                 "As a fraction holder of IPNFT #",
                 Strings.toString(frac.tokenId),
-                ", I accept all terms that I've read here: ",
-                Strings.toHexString(uint256(frac.agreementHash)),
+                ", I accept all terms that I've read here: ipfs://",
+                frac.agreementCid,
                 "\n\n",
                 "Chain Id: ",
                 Strings.toString(block.chainid),
@@ -278,8 +278,8 @@ contract Fractionalizer is ERC1155SupplyUpgradeable, UUPSUpgradeable, ERC2771Con
                 collection,
                 '","token_id": ',
                 tokenId,
-                ',"agreement_hash": "',
-                Strings.toHexString(uint256(frac.agreementHash)),
+                ',"agreement_content": "ipfs://',
+                frac.agreementCid,
                 '","original_owner": "',
                 Strings.toHexString(frac.originalOwner),
                 '","supply": ',

--- a/src/FractionalizerL2Dispatcher.sol
+++ b/src/FractionalizerL2Dispatcher.sol
@@ -53,13 +53,16 @@ contract FractionalizerL2Dispatcher is UUPSUpgradeable, OwnableUpgradeable {
      * @param collection      IERC1155  any erc1155 token collection that signals their token amount
      * @param tokenId          uint256  the token id on the origin collection
      * @param recipient        address  an account that will receive all fractions on L2
-     * @param agreementHash    bytes32  a content hash that identifies the terms underlying the issued fractions
+     * @param agreementCid    bytes32  a content hash that identifies the terms underlying the issued fractions
      * @param initialAmount  uint256  the initial amount of fractions issued
      */
-    function initializeFractionalization(IERC1155Supply collection, uint256 tokenId, address recipient, bytes32 agreementHash, uint256 initialAmount)
-        external
-        returns (uint256)
-    {
+    function initializeFractionalization(
+        IERC1155Supply collection,
+        uint256 tokenId,
+        address recipient,
+        string calldata agreementCid,
+        uint256 initialAmount
+    ) external returns (uint256) {
         if (collection.totalSupply(tokenId) != 1) {
             revert("can only fractionalize ERC1155 tokens with a supply of 1");
         }
@@ -72,13 +75,13 @@ contract FractionalizerL2Dispatcher is UUPSUpgradeable, OwnableUpgradeable {
         fractionalized[fractionId] = Fractionalized(collection, tokenId, _msgSender(), 0);
 
         bytes memory message = abi.encodeWithSignature(
-            "fractionalizeUniqueERC1155(uint256,address,uint256,address,address,bytes32,uint256)",
+            "fractionalizeUniqueERC1155(uint256,address,uint256,address,address,string,uint256)",
             fractionId,
             collection,
             tokenId,
             _msgSender(),
             recipient,
-            agreementHash,
+            agreementCid,
             initialAmount
         );
 

--- a/subgraphs/config/goerli.js
+++ b/subgraphs/config/goerli.js
@@ -7,7 +7,7 @@ module.exports = {
     startBlock: 8151797
   },
   schmackoSwap: {
-    address: '0x2365BEDC04Fb449718D3143C88aF73ad83d7b9B6',
+    address: '0x2b3e3F64bEe5E184981836d0599d51935d669701',
     startBlock: 8151797
   },
   mintpass: {
@@ -16,7 +16,7 @@ module.exports = {
   },
   // L2
   fractionalizer: {
-    address: '0x7DA77f8a834369dDc5e9e47407C9746Ed55C3b72',
-    startBlock: 7380525
+    address: '0x0803599ef1e4A479f5B7862994Af94178a1f74e4',
+    startBlock: 7889633
   }
 };

--- a/subgraphs/layer1/abis/FractionalizerL2Dispatcher.json
+++ b/subgraphs/layer1/abis/FractionalizerL2Dispatcher.json
@@ -192,9 +192,9 @@
         "type": "address"
       },
       {
-        "internalType": "bytes32",
-        "name": "agreementHash",
-        "type": "bytes32"
+        "internalType": "string",
+        "name": "agreementCid",
+        "type": "string"
       },
       {
         "internalType": "uint256",

--- a/subgraphs/layer2/abis/Fractionalizer.json
+++ b/subgraphs/layer2/abis/Fractionalizer.json
@@ -135,9 +135,9 @@
       },
       {
         "indexed": false,
-        "internalType": "bytes32",
-        "name": "agreementHash",
-        "type": "bytes32"
+        "internalType": "string",
+        "name": "agreementCid",
+        "type": "string"
       }
     ],
     "name": "FractionsCreated",
@@ -546,9 +546,9 @@
         "type": "address"
       },
       {
-        "internalType": "bytes32",
-        "name": "agreementHash",
-        "type": "bytes32"
+        "internalType": "string",
+        "name": "agreementCid",
+        "type": "string"
       },
       {
         "internalType": "uint256",
@@ -592,9 +592,9 @@
         "type": "address"
       },
       {
-        "internalType": "bytes32",
-        "name": "agreementHash",
-        "type": "bytes32"
+        "internalType": "string",
+        "name": "agreementCid",
+        "type": "string"
       },
       {
         "internalType": "contract IERC20",

--- a/subgraphs/layer2/schema.graphql
+++ b/subgraphs/layer2/schema.graphql
@@ -4,7 +4,7 @@ type FracIpnft @entity {
   createdAt: BigInt!
   ipnftCollection: Bytes #address of the collection
   ipnftId: ID # tokenID of original Ipnft
-  agreementHash: Bytes #hash of FAM Agreement probably an IPFS hash
+  agreementCid: String #IPFS CID string of FAM Agreement
   totalIssued: BigInt! #the amount of fractions issued; can be increased later
   circulatingSupply: BigInt! #the amount of fractions that are in circulation
   claimedShares: BigInt! # the amount of shares that have already been claimed. This needs to have a fulfilledListingId to be set

--- a/subgraphs/layer2/src/fractionalizerMappings.ts
+++ b/subgraphs/layer2/src/fractionalizerMappings.ts
@@ -22,7 +22,7 @@ export function handleFractionsCreated(event: FractionsCreatedEvent): void {
   frac.ipnftCollection = event.params.collection;
   frac.originalOwner = event.params.emitter;
   frac.ipnftId = event.params.tokenId.toString();
-  frac.agreementHash = event.params.agreementHash;
+  frac.agreementCid = event.params.agreementCid;
 
   createOrUpdateFracBasket(
     event.params.emitter,

--- a/subgraphs/layer2/subgraph.template.yaml
+++ b/subgraphs/layer2/subgraph.template.yaml
@@ -20,7 +20,7 @@ dataSources:
         - name: Fractionalizer
           file: ./abis/Fractionalizer.json
       eventHandlers:
-        - event: FractionsCreated(indexed address,indexed uint256,address,indexed uint256,uint256,bytes32)
+        - event: FractionsCreated(indexed address,indexed uint256,address,indexed uint256,uint256,string)
           handler: handleFractionsCreated
         - event: TransferSingle(indexed address,indexed address,indexed address,uint256,uint256)
           handler: handleTransferSingle

--- a/test/L1FractionalizerDispatcher.t.sol
+++ b/test/L1FractionalizerDispatcher.t.sol
@@ -26,7 +26,7 @@ import { MyToken } from "../src/MyToken.sol";
 
 contract L1FractionalizerDispatcher is Test {
     string ipfsUri = "ipfs://bafkreiankqd3jvpzso6khstnaoxovtyezyatxdy7t2qzjoolqhltmasqki";
-    bytes32 agreementHash = keccak256(bytes("the binary content of the fraction holder agreeemnt"));
+    string agreementCid = "bafkreigk5dvqblnkdniges6ft5kmuly47ebw4vho6siikzmkaovq6sjstq";
 
     address deployer = makeAddr("chucknorris");
     address protocolOwner = makeAddr("protocolOwner");
@@ -97,7 +97,7 @@ contract L1FractionalizerDispatcher is Test {
     function testInitiatingFractions() public {
         vm.startPrank(originalOwner);
         ipnft.setApprovalForAll(address(fractionalizer), true);
-        fractionalizer.initializeFractionalization(ipnft, 1, originalOwner, agreementHash, 100_000);
+        fractionalizer.initializeFractionalization(ipnft, 1, originalOwner, agreementCid, 100_000);
         vm.stopPrank();
     }
 
@@ -112,7 +112,7 @@ contract L1FractionalizerDispatcher is Test {
     function testCreateListingAndSell() public {
         vm.startPrank(originalOwner);
         ipnft.setApprovalForAll(address(fractionalizer), true);
-        fractionalizer.initializeFractionalization(ipnft, 1, originalOwner, agreementHash, 100_000);
+        fractionalizer.initializeFractionalization(ipnft, 1, originalOwner, agreementCid, 100_000);
         uint256 listingId = helpCreateListing(1_000_000 ether);
         vm.stopPrank();
 
@@ -136,7 +136,7 @@ contract L1FractionalizerDispatcher is Test {
     function testStartClaimingPhase() public {
         vm.startPrank(originalOwner);
         ipnft.setApprovalForAll(address(fractionalizer), true);
-        uint256 fractionId = fractionalizer.initializeFractionalization(ipnft, 1, originalOwner, agreementHash, 100_000);
+        uint256 fractionId = fractionalizer.initializeFractionalization(ipnft, 1, originalOwner, agreementCid, 100_000);
         uint256 listingId = helpCreateListing(1_000_000 ether);
         vm.stopPrank();
 
@@ -158,7 +158,7 @@ contract L1FractionalizerDispatcher is Test {
 
     function testManuallyStartClaimingPhase() public {
         vm.startPrank(originalOwner);
-        uint256 fractionId = fractionalizer.initializeFractionalization(ipnft, 1, originalOwner, agreementHash, 100_000);
+        uint256 fractionId = fractionalizer.initializeFractionalization(ipnft, 1, originalOwner, agreementCid, 100_000);
         erc20.approve(address(fractionalizer), 1_000_000 ether);
         ipnft.safeTransferFrom(originalOwner, ipnftBuyer, 1, 1, "");
         vm.stopPrank();

--- a/test/L2Fractionalizer.t.sol
+++ b/test/L2Fractionalizer.t.sol
@@ -21,7 +21,7 @@ import { MyToken } from "../src/MyToken.sol";
 
 contract L2FractionalizerTest is Test {
     string ipfsUri = "ipfs://bafkreiankqd3jvpzso6khstnaoxovtyezyatxdy7t2qzjoolqhltmasqki";
-    bytes32 agreementHash = keccak256(bytes("the binary content of the fraction holder agreeemnt"));
+    string agreementCid = "bafkreigk5dvqblnkdniges6ft5kmuly47ebw4vho6siikzmkaovq6sjstq";
 
     address PREDEPLOYED_XDOMAIN_MESSENGER = 0x4200000000000000000000000000000000000007;
 
@@ -77,7 +77,7 @@ contract L2FractionalizerTest is Test {
 
         xDomainMessenger.setSender(FakeL1DispatcherContract);
         bytes memory message = abi.encodeCall(
-            Fractionalizer.fractionalizeUniqueERC1155, (fractionId, ipnftContract, uint256(1), originalOwner, originalOwner, agreementHash, 100_000)
+            Fractionalizer.fractionalizeUniqueERC1155, (fractionId, ipnftContract, uint256(1), originalOwner, originalOwner, agreementCid, 100_000)
         );
 
         xDomainMessenger.sendMessage(address(fractionalizer), message, 1_900_000);
@@ -142,7 +142,7 @@ contract L2FractionalizerTest is Test {
             address(fractionalizer),
             abi.encodeCall(
                 Fractionalizer.fractionalizeUniqueERC1155,
-                (fractionId, ipnftContract, uint256(1), originalOwner, originalOwner, agreementHash, 200_000)
+                (fractionId, ipnftContract, uint256(1), originalOwner, originalOwner, agreementCid, 200_000)
             ),
             1_900_000
         );
@@ -156,7 +156,7 @@ contract L2FractionalizerTest is Test {
             address(fractionalizer),
             abi.encodeCall(
                 Fractionalizer.fractionalizeUniqueERC1155,
-                (fractionId, ipnftContract, uint256(2), originalOwner, originalOwner, agreementHash, 200_000)
+                (fractionId, ipnftContract, uint256(2), originalOwner, originalOwner, agreementCid, 200_000)
             ),
             1_900_000
         );
@@ -332,7 +332,7 @@ contract L2FractionalizerTest is Test {
 
         xDomainMessenger.setSender(FakeL1DispatcherContract);
         bytes memory message = abi.encodeCall(
-            fractionalizer.fractionalizeUniqueERC1155, (fractionId, ipnftContract, uint256(1), originalOwner, address(wallet), agreementHash, 100_000)
+            fractionalizer.fractionalizeUniqueERC1155, (fractionId, ipnftContract, uint256(1), originalOwner, address(wallet), agreementCid, 100_000)
         );
 
         xDomainMessenger.sendMessage(address(fractionalizer), message, 2_900_000);

--- a/test/L2Fractionalizer.t.sol
+++ b/test/L2Fractionalizer.t.sol
@@ -262,7 +262,7 @@ contract L2FractionalizerTest is Test {
 
         xDomainMessenger.setSender(FakeL1DispatcherContract);
         bytes memory message = abi.encodeCall(
-            Fractionalizer.fractionalizeUniqueERC1155, (fractionId, ipnftContract, uint256(1), originalOwner, alice, agreementHash, __wealth)
+            Fractionalizer.fractionalizeUniqueERC1155, (fractionId, ipnftContract, uint256(1), originalOwner, alice, agreementCid, __wealth)
         );
 
         xDomainMessenger.sendMessage(address(fractionalizer), message, 1_900_000);

--- a/test/L2FractionalizerMeta.t.sol
+++ b/test/L2FractionalizerMeta.t.sol
@@ -16,7 +16,7 @@ import { MyToken } from "../src/MyToken.sol";
 
 contract L2FractionalizerMetaTest is Test {
     string ipfsUri = "ipfs://bafkreiankqd3jvpzso6khstnaoxovtyezyatxdy7t2qzjoolqhltmasqki";
-    bytes32 agreementHash = keccak256(bytes("the binary content of the fraction holder agreeemnt"));
+    string agreementCid = "bafkreigk5dvqblnkdniges6ft5kmuly47ebw4vho6siikzmkaovq6sjstq";
 
     address PREDEPLOYED_XDOMAIN_MESSENGER = 0x4200000000000000000000000000000000000007;
 
@@ -75,7 +75,7 @@ contract L2FractionalizerMetaTest is Test {
 
         xDomainMessenger.setSender(FakeL1DispatcherContract);
         bytes memory message = abi.encodeCall(
-            Fractionalizer.fractionalizeUniqueERC1155, (fractionId, ipnftContract, uint256(1), originalOwner, originalOwner, agreementHash, 100_000)
+            Fractionalizer.fractionalizeUniqueERC1155, (fractionId, ipnftContract, uint256(1), originalOwner, originalOwner, agreementCid, 100_000)
         );
 
         xDomainMessenger.sendMessage(address(fractionalizer), message, 1_900_000);


### PR DESCRIPTION
base32 recoding would be far more expensive during the signing process