### PR TITLE
Adds event to index fractionalization init request

### DIFF
--- a/src/FractionalizerL2Dispatcher.sol
+++ b/src/FractionalizerL2Dispatcher.sol
@@ -29,6 +29,8 @@ contract FractionalizerL2Dispatcher is UUPSUpgradeable, OwnableUpgradeable {
         uint256 fulfilledListingId;
     }
 
+    event FractionalizationInitiated(IERC1155Supply indexed collection, uint256 indexed tokenId, address indexed initiator, uint256 initialAmount);
+
     uint32 constant MIN_GASLIMIT = 1_000_000;
 
     ContractRegistry registry;
@@ -90,6 +92,8 @@ contract FractionalizerL2Dispatcher is UUPSUpgradeable, OwnableUpgradeable {
 
         address crossDomainMessengerAddr = registry.safeGet("CrossdomainMessenger");
         ICrossDomainMessenger(crossDomainMessengerAddr).sendMessage(registry.safeGet("FractionalizerL2"), message, MIN_GASLIMIT);
+
+        emit FractionalizationInitiated(collection, tokenId, _msgSender(), initialAmount);
 
         return fractionId;
     }

--- a/subgraphs/config/goerli.js
+++ b/subgraphs/config/goerli.js
@@ -14,6 +14,10 @@ module.exports = {
     address: '0xAf0f99dcC64E8a6549d32013AC9f2C3FA7834688',
     startBlock: 8151797
   },
+  fractionalizerL2Dispatcher: {
+    address: '0x1765b6823BAFa0DfF99bA05077C2b3642695152d',
+    startBlock: 8811342
+  },
   // L2
   fractionalizer: {
     address: '0x0803599ef1e4A479f5B7862994Af94178a1f74e4',

--- a/subgraphs/layer1/abis/FractionalizerL2Dispatcher.json
+++ b/subgraphs/layer1/abis/FractionalizerL2Dispatcher.json
@@ -40,6 +40,37 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": true,
+        "internalType": "contract IERC1155Supply",
+        "name": "collection",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "initiator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "initialAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "FractionalizationInitiated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": false,
         "internalType": "uint8",
         "name": "version",

--- a/subgraphs/layer1/schema.graphql
+++ b/subgraphs/layer1/schema.graphql
@@ -1,11 +1,22 @@
 type Ipnft @entity {
   id: ID! #tokenId
   owner: Bytes! # address
+  originalOwner: Bytes! # address of original minter
   createdAt: BigInt!
   tokenURI: String!
   listings: [Listing!] @derivedFrom(field: "ipnft")
   symbol: String
   readers: [CanRead!] @derivedFrom(field: "ipnft")
+  fracTxHash: Bytes
+  fracInit: FracInit @derivedFrom(field: "ipnft")
+}
+
+type FracInit @entity {
+  id: ID! # fractionId
+  emitter: Bytes! # address
+  ipnft: Ipnft!
+  collection: Bytes! # address of collection
+  initialAmount: BigInt! # initial amount of tokens
 }
 
 type Listing @entity {

--- a/subgraphs/layer1/src/dispatcherMapping.ts
+++ b/subgraphs/layer1/src/dispatcherMapping.ts
@@ -1,0 +1,19 @@
+import { FractionalizationInitiated as FractionalizationInitiatedEvent } from '../generated/FractionalizerL2Dispatcher/FractionalizerL2Dispatcher';
+import { FracInit, Ipnft } from '../generated/schema';
+
+export function handleFractionalizationInitiated(
+  event: FractionalizationInitiatedEvent
+): void {
+  let ipnft = Ipnft.load(event.params.tokenId.toString());
+  if (!ipnft) {
+    return;
+  }
+  ipnft.fracTxHash = event.transaction.hash;
+  ipnft.save();
+
+  let fracInit = new FracInit(event.params.tokenId.toString());
+  fracInit.collection = event.params.collection;
+  fracInit.emitter = event.params.initiator;
+  fracInit.initialAmount = event.params.initialAmount;
+  fracInit.ipnft = ipnft.id;
+}

--- a/subgraphs/layer1/src/ipnftMapping.ts
+++ b/subgraphs/layer1/src/ipnftMapping.ts
@@ -73,6 +73,7 @@ export function handleMint(event: IPNFTMintedEvent): void {
   ipnft.owner = event.params.owner;
   ipnft.tokenURI = event.params.tokenURI;
   ipnft.createdAt = event.block.timestamp;
+  ipnft.originalOwner = event.params.owner;
   ipnft.save();
 
   store.remove('Reservation', event.params.tokenId.toString());

--- a/subgraphs/layer1/subgraph.template.yaml
+++ b/subgraphs/layer1/subgraph.template.yaml
@@ -29,7 +29,6 @@ dataSources:
           handler: handleTransferSingle
         - event: ReadAccessGranted(indexed uint256,indexed address,uint256)
           handler: handleReadAccess
-          
       file: ./src/ipnftMapping.ts
   - kind: ethereum
     name: SchmackoSwap
@@ -81,3 +80,23 @@ dataSources:
         - event: Redeemed(indexed uint256)
           handler: handleRedeemed
       file: ./src/mintpassMapping.ts
+  - kind: ethereum
+    name: FractionalizerL2Dispatcher
+    network: {{networkL1}}
+    source:
+      address: '{{fractionalizerL2Dispatcher.address}}'
+      abi: FractionalizerL2Dispatcher
+      startBlock: {{fractionalizerL2Dispatcher.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - IPNFT
+      abis:
+        - name: FractionalizerL2Dispatcher
+          file: ./abis/FractionalizerL2Dispatcher.json
+      eventHandlers:
+        - event: FractionalizationInitiated(indexed address,indexed uint256,indexed address,uint256)
+          handler: handleFractionalizationInitiated
+      file: ./src/dispatcherMapping.ts

--- a/subgraphs/layer2/abis/Fractionalizer.json
+++ b/subgraphs/layer2/abis/Fractionalizer.json
@@ -377,6 +377,29 @@
       },
       {
         "internalType": "address",
+        "name": "onBehalf",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "signature",
+        "type": "bytes"
+      }
+    ],
+    "name": "acceptTerms",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "fractionId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
         "name": "paymentToken",
         "type": "address"
       },


### PR DESCRIPTION
The goal here is to store some basic information about the initialization request from L1.
This allows for easily building a frontend displaying date of the initialization & status of the bridging to the L2.

- emits event when fractionalization is initiated
- updates subgraph to catch that event
- adds new entity for l1 subgraph that stores when frac is initiated per ipnft
- stores originalOwner of ipnft
