### PR TITLE
carries over IPNFT symbols to L2

### DIFF
--- a/src/Fractionalizer.sol
+++ b/src/Fractionalizer.sol
@@ -240,7 +240,9 @@ contract Fractionalizer is ERC1155SupplyUpgradeable, UUPSUpgradeable, ERC2771Con
 
         return string(
             abi.encodePacked(
-                "As a fraction holder of IPNFT #",
+                "As a fraction holder (",
+                frac.symbol,
+                ") of IPNFT #",
                 Strings.toString(frac.tokenId),
                 ", I accept all terms that I've read here: ipfs://",
                 frac.agreementCid,

--- a/subgraphs/layer1/abis/FractionalizerL2Dispatcher.json
+++ b/subgraphs/layer1/abis/FractionalizerL2Dispatcher.json
@@ -239,14 +239,19 @@
         "type": "address"
       },
       {
+        "internalType": "uint256",
+        "name": "initialAmount",
+        "type": "uint256"
+      },
+      {
         "internalType": "string",
         "name": "agreementCid",
         "type": "string"
       },
       {
-        "internalType": "uint256",
-        "name": "initialAmount",
-        "type": "uint256"
+        "internalType": "string",
+        "name": "symbol",
+        "type": "string"
       }
     ],
     "name": "initializeFractionalization",

--- a/subgraphs/layer2/abis/Fractionalizer.json
+++ b/subgraphs/layer2/abis/Fractionalizer.json
@@ -138,6 +138,12 @@
         "internalType": "string",
         "name": "agreementCid",
         "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "symbol",
+        "type": "string"
       }
     ],
     "name": "FractionsCreated",
@@ -569,14 +575,19 @@
         "type": "address"
       },
       {
+        "internalType": "uint256",
+        "name": "fractionsAmount",
+        "type": "uint256"
+      },
+      {
         "internalType": "string",
         "name": "agreementCid",
         "type": "string"
       },
       {
-        "internalType": "uint256",
-        "name": "fractionsAmount",
-        "type": "uint256"
+        "internalType": "string",
+        "name": "_symbol",
+        "type": "string"
       }
     ],
     "name": "fractionalizeUniqueERC1155",
@@ -628,6 +639,11 @@
         "internalType": "uint256",
         "name": "paidPrice",
         "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "symbol",
+        "type": "string"
       }
     ],
     "stateMutability": "view",
@@ -943,6 +959,25 @@
         "internalType": "bool",
         "name": "",
         "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "fractionId",
+        "type": "uint256"
+      }
+    ],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
       }
     ],
     "stateMutability": "view",

--- a/subgraphs/layer2/schema.graphql
+++ b/subgraphs/layer2/schema.graphql
@@ -5,6 +5,7 @@ type FracIpnft @entity {
   ipnftCollection: Bytes #address of the collection
   ipnftId: ID # tokenID of original Ipnft
   agreementCid: String #IPFS CID string of FAM Agreement
+  symbol: String #the FAM symbol (IPNFT symbol + -FAM)
   totalIssued: BigInt! #the amount of fractions issued; can be increased later
   circulatingSupply: BigInt! #the amount of fractions that are in circulation
   claimedShares: BigInt! # the amount of shares that have already been claimed. This needs to have a fulfilledListingId to be set

--- a/subgraphs/layer2/src/fractionalizerMappings.ts
+++ b/subgraphs/layer2/src/fractionalizerMappings.ts
@@ -23,6 +23,7 @@ export function handleFractionsCreated(event: FractionsCreatedEvent): void {
   frac.originalOwner = event.params.emitter;
   frac.ipnftId = event.params.tokenId.toString();
   frac.agreementCid = event.params.agreementCid;
+  frac.symbol = event.params.symbol;
 
   createOrUpdateFracBasket(
     event.params.emitter,

--- a/subgraphs/layer2/subgraph.template.yaml
+++ b/subgraphs/layer2/subgraph.template.yaml
@@ -20,7 +20,7 @@ dataSources:
         - name: Fractionalizer
           file: ./abis/Fractionalizer.json
       eventHandlers:
-        - event: FractionsCreated(indexed address,indexed uint256,address,indexed uint256,uint256,string)
+        - event: FractionsCreated(indexed address,indexed uint256,address,indexed uint256,uint256,string,string)
           handler: handleFractionsCreated
         - event: TransferSingle(indexed address,indexed address,indexed address,uint256,uint256)
           handler: handleTransferSingle

--- a/test/L1FractionalizerDispatcher.t.sol
+++ b/test/L1FractionalizerDispatcher.t.sol
@@ -27,6 +27,7 @@ import { MyToken } from "../src/MyToken.sol";
 contract L1FractionalizerDispatcher is Test {
     string ipfsUri = "ipfs://bafkreiankqd3jvpzso6khstnaoxovtyezyatxdy7t2qzjoolqhltmasqki";
     string agreementCid = "bafkreigk5dvqblnkdniges6ft5kmuly47ebw4vho6siikzmkaovq6sjstq";
+    string ipnftSymbol = "MOL-0001";
 
     address deployer = makeAddr("chucknorris");
     address protocolOwner = makeAddr("protocolOwner");
@@ -92,7 +93,7 @@ contract L1FractionalizerDispatcher is Test {
         vm.deal(originalOwner, 0.001 ether);
         vm.startPrank(originalOwner);
         uint256 reservationId = _ipnft.reserve();
-        _ipnft.mintReservation{ value: 0.001 ether }(originalOwner, reservationId, 1, ipfsUri);
+        _ipnft.mintReservation{ value: 0.001 ether }(originalOwner, reservationId, 1, ipfsUri, ipnftSymbol);
         vm.stopPrank();
     }
 
@@ -107,7 +108,7 @@ contract L1FractionalizerDispatcher is Test {
             FractionalizerL2Dispatcher.Fractionalized({ collection: ipnft, tokenId: 1, originalOwner: originalOwner, fulfilledListingId: 0 }),
             100_000
         );
-        fractionalizer.initializeFractionalization(ipnft, 1, originalOwner, agreementCid, 100_000);
+        fractionalizer.initializeFractionalization(ipnft, 1, originalOwner, 100_000, agreementCid, ipnftSymbol);
         vm.stopPrank();
     }
 
@@ -122,7 +123,7 @@ contract L1FractionalizerDispatcher is Test {
     function testCreateListingAndSell() public {
         vm.startPrank(originalOwner);
         ipnft.setApprovalForAll(address(fractionalizer), true);
-        fractionalizer.initializeFractionalization(ipnft, 1, originalOwner, agreementCid, 100_000);
+        fractionalizer.initializeFractionalization(ipnft, 1, originalOwner, 100_000, agreementCid, ipnftSymbol);
         uint256 listingId = helpCreateListing(1_000_000 ether);
         vm.stopPrank();
 
@@ -146,7 +147,7 @@ contract L1FractionalizerDispatcher is Test {
     function testStartClaimingPhase() public {
         vm.startPrank(originalOwner);
         ipnft.setApprovalForAll(address(fractionalizer), true);
-        uint256 fractionId = fractionalizer.initializeFractionalization(ipnft, 1, originalOwner, agreementCid, 100_000);
+        uint256 fractionId = fractionalizer.initializeFractionalization(ipnft, 1, originalOwner, 100_000, agreementCid, ipnftSymbol);
         uint256 listingId = helpCreateListing(1_000_000 ether);
         vm.stopPrank();
 
@@ -168,7 +169,7 @@ contract L1FractionalizerDispatcher is Test {
 
     function testManuallyStartClaimingPhase() public {
         vm.startPrank(originalOwner);
-        uint256 fractionId = fractionalizer.initializeFractionalization(ipnft, 1, originalOwner, agreementCid, 100_000);
+        uint256 fractionId = fractionalizer.initializeFractionalization(ipnft, 1, originalOwner, 100_000, agreementCid, ipnftSymbol);
         erc20.approve(address(fractionalizer), 1_000_000 ether);
         ipnft.safeTransferFrom(originalOwner, ipnftBuyer, 1, 1, "");
         vm.stopPrank();
@@ -196,7 +197,7 @@ contract L1FractionalizerDispatcher is Test {
 
         vm.startPrank(originalOwner);
         vm.expectRevert("can only fractionalize ERC1155 tokens with a supply of 1");
-        fractionalizer.initializeFractionalization(IERC1155Supply(address(erc1155)), 1, alice, "", 100_000);
+        fractionalizer.initializeFractionalization(IERC1155Supply(address(erc1155)), 1, alice, 100_000, "", ipnftSymbol);
         vm.stopPrank();
     }
 }

--- a/test/L2Fractionalizer.t.sol
+++ b/test/L2Fractionalizer.t.sol
@@ -22,6 +22,7 @@ import { MyToken } from "../src/MyToken.sol";
 contract L2FractionalizerTest is Test {
     string ipfsUri = "ipfs://bafkreiankqd3jvpzso6khstnaoxovtyezyatxdy7t2qzjoolqhltmasqki";
     string agreementCid = "bafkreigk5dvqblnkdniges6ft5kmuly47ebw4vho6siikzmkaovq6sjstq";
+    string ipnftSymbol = "MOL-0001-FAM";
 
     address PREDEPLOYED_XDOMAIN_MESSENGER = 0x4200000000000000000000000000000000000007;
 
@@ -77,7 +78,8 @@ contract L2FractionalizerTest is Test {
 
         xDomainMessenger.setSender(FakeL1DispatcherContract);
         bytes memory message = abi.encodeCall(
-            Fractionalizer.fractionalizeUniqueERC1155, (fractionId, ipnftContract, uint256(1), originalOwner, originalOwner, agreementCid, 100_000)
+            Fractionalizer.fractionalizeUniqueERC1155,
+            (fractionId, ipnftContract, uint256(1), originalOwner, originalOwner, 100_000, agreementCid, ipnftSymbol)
         );
 
         xDomainMessenger.sendMessage(address(fractionalizer), message, 1_900_000);
@@ -98,7 +100,7 @@ contract L2FractionalizerTest is Test {
 
         assertEq(fractionalizer.balanceOf(originalOwner, fractionId), 100_000);
 
-        (,, uint256 totalIssued,,,,) = fractionalizer.fractionalized(fractionId);
+        (,, uint256 totalIssued,,,,,) = fractionalizer.fractionalized(fractionId);
         assertEq(totalIssued, 100_000);
 
         vm.startPrank(originalOwner);
@@ -108,6 +110,7 @@ contract L2FractionalizerTest is Test {
         assertEq(fractionalizer.balanceOf(alice, fractionId), 10_000);
         assertEq(fractionalizer.balanceOf(originalOwner, fractionId), 90_000);
         assertEq(fractionalizer.totalSupply(fractionId), 100_000);
+        assertEq(fractionalizer.symbol(fractionId), ipnftSymbol);
     }
 
     function testIncreaseFractions() public {
@@ -130,7 +133,7 @@ contract L2FractionalizerTest is Test {
         assertEq(fractionalizer.balanceOf(originalOwner, fractionId), 150_000);
         assertEq(fractionalizer.totalSupply(fractionId), 200_000);
 
-        (,, uint256 totalIssued,,,,) = fractionalizer.fractionalized(fractionId);
+        (,, uint256 totalIssued,,,,,) = fractionalizer.fractionalized(fractionId);
         assertEq(totalIssued, 200_000);
     }
 
@@ -142,7 +145,7 @@ contract L2FractionalizerTest is Test {
             address(fractionalizer),
             abi.encodeCall(
                 Fractionalizer.fractionalizeUniqueERC1155,
-                (fractionId, ipnftContract, uint256(1), originalOwner, originalOwner, agreementCid, 200_000)
+                (fractionId, ipnftContract, uint256(1), originalOwner, originalOwner, 200_000, agreementCid, ipnftSymbol)
             ),
             1_900_000
         );
@@ -156,7 +159,7 @@ contract L2FractionalizerTest is Test {
             address(fractionalizer),
             abi.encodeCall(
                 Fractionalizer.fractionalizeUniqueERC1155,
-                (fractionId, ipnftContract, uint256(2), originalOwner, originalOwner, agreementCid, 200_000)
+                (fractionId, ipnftContract, uint256(2), originalOwner, originalOwner, 200_000, agreementCid, ipnftSymbol)
             ),
             1_900_000
         );
@@ -262,7 +265,8 @@ contract L2FractionalizerTest is Test {
 
         xDomainMessenger.setSender(FakeL1DispatcherContract);
         bytes memory message = abi.encodeCall(
-            Fractionalizer.fractionalizeUniqueERC1155, (fractionId, ipnftContract, uint256(1), originalOwner, alice, agreementCid, __wealth)
+            Fractionalizer.fractionalizeUniqueERC1155,
+            (fractionId, ipnftContract, uint256(1), originalOwner, alice, __wealth, agreementCid, ipnftSymbol)
         );
 
         xDomainMessenger.sendMessage(address(fractionalizer), message, 1_900_000);
@@ -349,7 +353,8 @@ contract L2FractionalizerTest is Test {
 
         xDomainMessenger.setSender(FakeL1DispatcherContract);
         bytes memory message = abi.encodeCall(
-            fractionalizer.fractionalizeUniqueERC1155, (fractionId, ipnftContract, uint256(1), originalOwner, address(wallet), agreementCid, 100_000)
+            fractionalizer.fractionalizeUniqueERC1155,
+            (fractionId, ipnftContract, uint256(1), originalOwner, address(wallet), 100_000, agreementCid, ipnftSymbol)
         );
 
         xDomainMessenger.sendMessage(address(fractionalizer), message, 2_900_000);

--- a/test/L2FractionalizerMeta.t.sol
+++ b/test/L2FractionalizerMeta.t.sol
@@ -75,7 +75,8 @@ contract L2FractionalizerMetaTest is Test {
 
         xDomainMessenger.setSender(FakeL1DispatcherContract);
         bytes memory message = abi.encodeCall(
-            Fractionalizer.fractionalizeUniqueERC1155, (fractionId, ipnftContract, uint256(1), originalOwner, originalOwner, agreementCid, 100_000)
+            Fractionalizer.fractionalizeUniqueERC1155,
+            (fractionId, ipnftContract, uint256(1), originalOwner, originalOwner, 100_000, agreementCid, "MOL-0001-FAM")
         );
 
         xDomainMessenger.sendMessage(address(fractionalizer), message, 1_900_000);


### PR DESCRIPTION
- the dispatcher requires a symbol, adds "-FAM" and dispatches it to L2.  
- Updates L2 metadata
- Updates subgraphs
- also regrouped the method parameters a little

https://moleculeto.notion.site/use-the-IPNFT-s-symbol-on-its-fractionalized-assets-7fa0697f021b4446a05c9db94a3dcec7