### PR TITLE
test case to demonstrate upgradeable token implementations

### DIFF
--- a/src/Fractionalizer.sol
+++ b/src/Fractionalizer.sol
@@ -42,10 +42,9 @@ error InvalidSignature();
 contract Fractionalizer is UUPSUpgradeable, OwnableUpgradeable {
     using SafeERC20 for IERC20;
 
-    //todo: rename tokenId to ipnftId
     event FractionsCreated(
         uint256 indexed fractionId,
-        uint256 indexed tokenId,
+        uint256 indexed ipnftId,
         address indexed tokenContract,
         address emitter,
         uint256 amount,
@@ -56,17 +55,19 @@ contract Fractionalizer is UUPSUpgradeable, OwnableUpgradeable {
     event SalesActivated(uint256 fractionId, address paymentToken, uint256 paidPrice);
     event TermsAccepted(uint256 indexed fractionId, address indexed signer, bytes signature);
     event SharesClaimed(uint256 indexed fractionId, address indexed claimer, uint256 amount);
-    //listen for mints instead:
-    //event FractionsEmitted(uint256 fractionId, uint256 amount);
 
     IPNFT ipnft;
     SchmackoSwap schmackoSwap;
 
     address feeReceiver;
     uint256 fractionalizationPercentage;
+
     mapping(uint256 => Fractionalized) public fractionalized;
+
+    //unused
     mapping(address => mapping(uint256 => uint256)) claimAllowance;
 
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     address immutable tokenImplementation;
 
     function initialize(IPNFT _ipnft, SchmackoSwap _schmackoSwap) public initializer {
@@ -84,6 +85,7 @@ contract Fractionalizer is UUPSUpgradeable, OwnableUpgradeable {
         _;
     }
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         tokenImplementation = address(new FractionalizedTokenUpgradeable());
         _disableInitializers();

--- a/src/helpers/upgrades/FractionalizerNext.sol
+++ b/src/helpers/upgrades/FractionalizerNext.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { ERC20BurnableUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
+
+import { Base64 } from "@openzeppelin/contracts/utils/Base64.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Clones } from "@openzeppelin/contracts/proxy/Clones.sol";
+
+import { SignatureChecker } from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+import { SchmackoSwap, ListingState } from "../../SchmackoSwap.sol";
+import { IPNFT } from "../../IPNFT.sol";
+
+struct Fractionalized {
+    uint256 tokenId;
+    //needed to remember an individual's share after others burn their tokens
+    uint256 totalIssued;
+    address originalOwner;
+    string agreementCid;
+    FractionalizedTokenUpgradeableNext tokenContract; //the erc20 token contract representing the fractions
+    uint256 fulfilledListingId;
+    IERC20 paymentToken;
+    uint256 paidPrice;
+}
+
+/// @title FractionalizedToken
+/// @author molecule.to
+/// @notice this is a template contract that's spawned by the fractionalizer
+/// @notice the owner of this contract is always the fractionalizer contract
+contract FractionalizedTokenUpgradeableNext is IERC20Upgradeable, ERC20Upgradeable, ERC20BurnableUpgradeable, OwnableUpgradeable {
+    uint256 public aNewStateVar;
+
+    function initialize(string memory name, string memory symbol) public initializer {
+        __Ownable_init();
+        __ERC20_init(name, symbol);
+    }
+
+    function issue(address receiver, uint256 amount) public onlyOwner {
+        _mint(receiver, amount);
+    }
+
+    function setAStateVar(uint256 newVal) public {
+        aNewStateVar = newVal;
+    }
+}
+
+/// @title Fractionalizer
+/// @author molecule.to
+/// @notice
+contract FractionalizerNext is UUPSUpgradeable, OwnableUpgradeable {
+    using SafeERC20 for IERC20;
+
+    event FractionsCreated(
+        uint256 indexed fractionId,
+        uint256 indexed ipnftId,
+        address indexed tokenContract,
+        address emitter,
+        uint256 amount,
+        string agreementCid,
+        string name,
+        string symbol
+    );
+
+    IPNFT ipnft;
+    SchmackoSwap schmackoSwap;
+
+    address feeReceiver;
+    uint256 fractionalizationPercentage;
+
+    mapping(uint256 => Fractionalized) public fractionalized;
+    mapping(address => mapping(uint256 => uint256)) claimAllowance;
+
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    address immutable tokenImplementation;
+
+    function initialize(IPNFT _ipnft, SchmackoSwap _schmackoSwap) public initializer {
+        __UUPSUpgradeable_init();
+        __Ownable_init();
+
+        ipnft = _ipnft;
+        schmackoSwap = _schmackoSwap;
+    }
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        tokenImplementation = address(new FractionalizedTokenUpgradeableNext());
+        _disableInitializers();
+    }
+
+    function balanceOf(address owner, uint256 fractionId) public view returns (uint256) {
+        return fractionalized[fractionId].tokenContract.balanceOf(owner);
+    }
+
+    function fractionalizeIpnft(uint256 ipnftId, uint256 fractionsAmount, string calldata agreementCid) external returns (uint256 fractionId) {
+        if (ipnft.totalSupply(ipnftId) != 1) {
+            revert("IPNFT supply must be 1");
+        }
+        if (ipnft.balanceOf(_msgSender(), ipnftId) != 1) {
+            revert("only owner can initialize fractions");
+        }
+        string memory ipnftSymbol = ipnft.symbol(ipnftId);
+        if (bytes(ipnftSymbol).length == 0) {
+            revert("ipnft needs a symbol to fractionalize");
+        }
+
+        fractionId = uint256(keccak256(abi.encodePacked(_msgSender(), ipnftId)));
+
+        if (address(fractionalized[fractionId].originalOwner) != address(0)) {
+            revert("token is already fractionalized");
+        }
+
+        FractionalizedTokenUpgradeableNext fractionalizedToken = FractionalizedTokenUpgradeableNext(Clones.clone(tokenImplementation));
+        string memory name = string(abi.encodePacked("Fractions of IPNFT #", Strings.toString(ipnftId)));
+        string memory symbol = string(string(abi.encodePacked(ipnftSymbol, "-MOL")));
+        (fractionalizedToken).initialize(name, symbol);
+
+        fractionalized[fractionId] =
+            Fractionalized(ipnftId, fractionsAmount, _msgSender(), agreementCid, fractionalizedToken, 0, IERC20(address(0)), 0);
+        fractionalizedToken.issue(_msgSender(), fractionsAmount);
+        emit FractionsCreated(fractionId, ipnftId, address(fractionalizedToken), _msgSender(), fractionsAmount, agreementCid, name, symbol);
+    }
+
+    function _authorizeUpgrade(address /*newImplementation*/ )
+        internal
+        override
+        onlyOwner // solhint-disable-next-line no-empty-blocks
+    { }
+}

--- a/test/IPNFT.t.js
+++ b/test/IPNFT.t.js
@@ -48,4 +48,20 @@ describe("IPNFT fundamentals and upgrades", function () {
     expect(1).to.eq(1)
   })
 
+  it("validates frax upgrade", async function () {
+    const Frac0 = await ethers.getContractFactory("Fractionalizer");
+    const frac0 = await upgrades.deployProxy(Frac0, [hre.ethers.constants.AddressZero,hre.ethers.constants.AddressZero], { kind: "uups" });
+
+    const result = await upgrades.validateUpgrade(
+      frac0.address,
+      await ethers.getContractFactory("FractionalizerNext"),
+      {
+        kind: "uups"
+      }
+    )
+    //this didn't throw :)
+    expect(1).to.eq(1)
+  })
+
+
 });


### PR DESCRIPTION
- proves that the inline ERC20 template contract is upgradeable at contract level
- replaces error string with error selectors
- adds tests for many edge cases, increases coverage by ~15%

```
before 
| File                                        | % Lines          | % Statements     | % Branches      | % Funcs         |
| src/Fractionalizer.sol                      | 73.81% (62/84)   | 74.47% (70/94)   | 59.38% (19/32)  | 76.47% (13/17)  |

after
| src/Fractionalizer.sol                      | 83.75% (67/80)   | 83.33% (75/90)   | 85.71% (24/28)  | 82.35% (14/17)  |
``` 