### PR TITLE
implements failed sales features

### DIFF
--- a/script/dev/CrowdSale.s.sol
+++ b/script/dev/CrowdSale.s.sol
@@ -114,7 +114,8 @@ contract FixtureCrowdSale is Script {
             biddingToken: FakeERC20(address(usdc)),
             fundingGoal: 200 ether,
             salesAmount: 400 ether,
-            closingTime: block.timestamp + 2 hours
+            openingTime: uint64(block.timestamp),
+            closingTime: uint64(block.timestamp + 2 hours)
         });
 
         vm.startBroadcast(bob);
@@ -139,7 +140,8 @@ contract FixtureCrowdSale is Script {
             biddingToken: FakeERC20(address(usdc)),
             fundingGoal: 200 ether,
             salesAmount: 400 ether,
-            closingTime: block.timestamp + 4 hours
+            openingTime: uint64(block.timestamp),
+            closingTime: uint64(block.timestamp + 4 hours)
         });
 
         vm.startBroadcast(bob);

--- a/setupLocal.sh
+++ b/setupLocal.sh
@@ -36,6 +36,10 @@ if [ "$fixture" -eq "1" ]; then
     forge script script/dev/CrowdSale.s.sol:DeployCrowdSale -f $RPC_URL --broadcast
     forge script script/dev/CrowdSale.s.sol:FixtureCrowdSale -f $RPC_URL --broadcast
 
+    sleep 5
+
+    echo "SALE_ID= forge script script/dev/CrowdSale.s.sol:ClaimSale -f $RPC_URL --broadcast"
+
 else
   echo "Only deploying contracts."
     forge script script/dev/Ipnft.s.sol:DeployIpnft -f $RPC_URL --broadcast

--- a/src/crowdsale/CrowdSale.sol
+++ b/src/crowdsale/CrowdSale.sol
@@ -9,6 +9,7 @@ import { FixedPointMathLib as FP } from "solmate/utils/FixedPointMathLib.sol";
 import { Counters } from "@openzeppelin/contracts/utils/Counters.sol";
 
 enum SaleState {
+    UNKNOWN, //Good to avoid invalid 0 checks
     RUNNING,
     SETTLED,
     FAILED

--- a/src/crowdsale/CrowdSale.sol
+++ b/src/crowdsale/CrowdSale.sol
@@ -8,6 +8,12 @@ import { FixedPointMathLib as FP } from "solmate/utils/FixedPointMathLib.sol";
 
 import { Counters } from "@openzeppelin/contracts/utils/Counters.sol";
 
+enum SaleState {
+    RUNNING,
+    SETTLED,
+    FAILED
+}
+
 struct Sale {
     IERC20Metadata auctionToken;
     IERC20 biddingToken;
@@ -16,12 +22,13 @@ struct Sale {
     uint256 fundingGoal;
     //how many auction tokens to sell
     uint256 salesAmount;
-    // uint256 openingTime;
-    uint256 closingTime;
+    uint64 openingTime;
+    uint64 closingTime;
 }
 
 struct SaleInfo {
-    bool settled;
+    address beneficiary;
+    SaleState state;
     uint256 total;
     uint256 surplus;
 }
@@ -44,6 +51,7 @@ contract CrowdSale {
     event Settled(uint256 indexed saleId, uint256 totalBids, uint256 surplus);
     event Claimed(uint256 indexed saleId, address indexed claimer, uint256 claimed, uint256 refunded);
     event Bid(uint256 indexed saleId, address indexed bidder, uint256 amount);
+    event Failed(uint256 saleId);
 
     constructor() { }
 
@@ -62,12 +70,13 @@ contract CrowdSale {
         //     revert("you must sell or accept something meaningful");
         // }
 
+        sale.openingTime = uint64(block.timestamp);
         saleId = uint256(keccak256(abi.encode(sale)));
         if (address(_sales[saleId].auctionToken) != address(0)) {
             revert SaleAlreadyActive();
         }
         _sales[saleId] = sale;
-        _saleInfo[saleId] = SaleInfo(false, 0, 0);
+        _saleInfo[saleId] = SaleInfo(msg.sender, SaleState.RUNNING, 0, 0);
 
         sale.auctionToken.safeTransferFrom(msg.sender, address(this), sale.salesAmount);
         _onSaleStarted(saleId);
@@ -87,8 +96,8 @@ contract CrowdSale {
             revert("bad sale id");
         }
 
-        if (_saleInfo[saleId].settled) {
-            revert("sale is already settled");
+        if (_saleInfo[saleId].state != SaleState.RUNNING) {
+            revert("sale is not running");
         }
 
         IERC20 biddingToken = sale.biddingToken;
@@ -98,22 +107,29 @@ contract CrowdSale {
         biddingToken.safeTransferFrom(msg.sender, address(this), biddingTokenAmount);
     }
 
+    /**
+     * @notice anyone can call this for the beneficiary
+     * @param saleId the sale id
+     */
     function settle(uint256 saleId) public virtual {
         Sale memory sale = _sales[saleId];
         SaleInfo storage __saleInfo = _saleInfo[saleId];
-        //todo anyone can call this for the beneficiary
-
-        //todo don't allow settlement before end time
 
         //todo: allow fundraiser to settle and allow everyone to withdraw if funding goal has *not* been met
-        if (__saleInfo.total < sale.fundingGoal) {
-            revert("funding goal not met");
-        }
-        if (__saleInfo.settled) {
-            revert("sale is already settled");
+        if (block.timestamp < sale.closingTime) {
+            revert("sale has not concluded yet");
         }
 
-        __saleInfo.settled = true;
+        if (__saleInfo.total < sale.fundingGoal) {
+            failSale(saleId);
+            return;
+        }
+
+        if (__saleInfo.state != SaleState.RUNNING) {
+            revert("sale is not running");
+        }
+
+        __saleInfo.state = SaleState.SETTLED;
         __saleInfo.surplus = __saleInfo.total - sale.fundingGoal;
 
         emit Settled(saleId, __saleInfo.total, __saleInfo.surplus);
@@ -123,13 +139,15 @@ contract CrowdSale {
     }
 
     function claim(uint256 saleId) public virtual returns (uint256 auctionTokens, uint256 refunds) {
-        (auctionTokens, refunds) = getClaimableAmounts(saleId, msg.sender);
-        emit Claimed(saleId, msg.sender, auctionTokens, refunds);
-
-        if (refunds > 0) {
-            _sales[saleId].biddingToken.safeTransfer(msg.sender, refunds);
+        if (_saleInfo[saleId].state == SaleState.RUNNING) {
+            revert("sale is not settled");
         }
-        _sales[saleId].auctionToken.safeTransfer(msg.sender, auctionTokens);
+        if (_saleInfo[saleId].state == SaleState.FAILED) {
+            return claimFailed(saleId);
+        }
+
+        (auctionTokens, refunds) = getClaimableAmounts(saleId, msg.sender);
+        claim(saleId, auctionTokens, refunds);
     }
 
     function saleInfo(uint256 saleId) public view returns (SaleInfo memory) {
@@ -138,6 +156,30 @@ contract CrowdSale {
 
     function contribution(uint256 saleId, address contributor) public view returns (uint256) {
         return _contributions[saleId][contributor];
+    }
+
+    function failSale(uint256 saleId) internal virtual {
+        Sale memory sale = _sales[saleId];
+        _saleInfo[saleId].state = SaleState.FAILED;
+        emit Failed(saleId);
+        sale.auctionToken.safeTransfer(_saleInfo[saleId].beneficiary, sale.salesAmount);
+    }
+
+    function claimFailed(uint256 saleId) internal virtual returns (uint256 auctionTokens, uint256 refunds) {
+        uint256 _contribution = _contributions[saleId][msg.sender];
+        _contributions[saleId][msg.sender] = 0;
+        emit Claimed(saleId, msg.sender, 0, _contribution);
+        _sales[saleId].biddingToken.safeTransfer(msg.sender, _contribution);
+        return (0, _contribution);
+    }
+
+    function claim(uint256 saleId, uint256 auctionTokens, uint256 refunds) internal virtual {
+        emit Claimed(saleId, msg.sender, auctionTokens, refunds);
+
+        if (refunds > 0) {
+            _sales[saleId].biddingToken.safeTransfer(msg.sender, refunds);
+        }
+        _sales[saleId].auctionToken.safeTransfer(msg.sender, auctionTokens);
     }
 
     function release(IERC20 biddingToken, address beneficiary, uint256 fundingGoal) internal virtual {

--- a/src/crowdsale/StakedVestedCrowdSale.sol
+++ b/src/crowdsale/StakedVestedCrowdSale.sol
@@ -102,13 +102,13 @@ contract StakedVestedCrowdSale is VestedCrowdSale {
     }
 
     //todo: get final price as by price feed at settlement
-    function claim(uint256 saleId) public override returns (uint256 auctionTokens, uint256 refunds) {
+    function claim(uint256 saleId, uint256 auctionTokens, uint256 refunds) internal virtual override {
         VestingConfig memory vestingConfig = salesVesting[saleId];
         StakingConfig memory stakingConfig = salesStaking[saleId];
 
         uint256 _stakes = stakes[saleId][msg.sender];
 
-        (auctionTokens, refunds) = super.claim(saleId);
+        super.claim(saleId, auctionTokens, refunds);
 
         uint256 refundedStakes = FP.mulWadDown(refunds, stakingConfig.wadFixedDaoPerBidPrice);
         uint256 vestedStakes = _stakes - refundedStakes;

--- a/src/crowdsale/StakedVestedCrowdSale.sol
+++ b/src/crowdsale/StakedVestedCrowdSale.sol
@@ -14,7 +14,7 @@ import { FixedPointMathLib as FP } from "solmate/utils/FixedPointMathLib.sol";
 import { TokenVesting } from "@moleculeprotocol/token-vesting/TokenVesting.sol";
 
 import { VestedCrowdSale, VestingConfig, ApprovalFailed } from "./VestedCrowdSale.sol";
-import { CrowdSale, Sale, BadDecimals } from "./CrowdSale.sol";
+import { CrowdSale, Sale, BadDecimals, SaleState } from "./CrowdSale.sol";
 import { InitializeableTokenVesting } from "./InitializableTokenVesting.sol";
 import { IPriceFeedConsumer } from "../BioPriceFeed.sol";
 
@@ -71,6 +71,10 @@ contract StakedVestedCrowdSale is VestedCrowdSale {
 
     function settle(uint256 saleId) public override {
         super.settle(saleId);
+        if (_saleInfo[saleId].state == SaleState.FAILED) {
+            return;
+        }
+
         StakingConfig storage staking = salesStaking[saleId];
         bool result = staking.stakedToken.approve(address(staking.stakesVestingContract), staking.stakeTotal);
         if (!result) {
@@ -81,21 +85,18 @@ contract StakedVestedCrowdSale is VestedCrowdSale {
     function placeBid(uint256 saleId, uint256 biddingTokenAmount) public override {
         StakingConfig storage staking = salesStaking[saleId];
 
-        //todo price calculation here:
-        uint256 price = 1;
-        uint256 stakedTokenAmount = biddingTokenAmount;
-
+        //todo use current price:
         //uint256 wadDaoInBiddingPrice = uint256(priceFeed.getPrice(address(_sales[saleId].biddingToken), address(staking.stakedToken)));
         // if (wadDaoInBiddingPrice == 0) {
         //     revert("no price available");
         // }
 
-        stakedTokenAmount = FP.mulWadDown(biddingTokenAmount, staking.wadFixedDaoPerBidPrice);
+        uint256 stakedTokenAmount = FP.mulWadDown(biddingTokenAmount, staking.wadFixedDaoPerBidPrice);
 
         staking.stakeTotal += stakedTokenAmount;
         stakes[saleId][msg.sender] += stakedTokenAmount;
 
-        emit Bid(saleId, msg.sender, biddingTokenAmount, stakedTokenAmount, price);
+        emit Bid(saleId, msg.sender, biddingTokenAmount, stakedTokenAmount, staking.wadFixedDaoPerBidPrice);
         staking.stakedToken.safeTransferFrom(msg.sender, address(this), stakedTokenAmount);
 
         super.placeBid(saleId, biddingTokenAmount);

--- a/src/crowdsale/VestedCrowdSale.sol
+++ b/src/crowdsale/VestedCrowdSale.sol
@@ -67,15 +67,14 @@ contract VestedCrowdSale is CrowdSale {
     }
 
     function settle(uint256 saleId) public virtual override {
-        Sale memory sale = _sales[saleId];
-        VestingConfig memory vesting = salesVesting[saleId];
-
         super.settle(saleId);
         if (_saleInfo[saleId].state == SaleState.FAILED) {
             return;
         }
 
-        bool result = _sales[saleId].auctionToken.approve(address(vesting.vestingContract), sale.salesAmount);
+        Sale memory sale = _sales[saleId];
+        VestingConfig memory vesting = salesVesting[saleId];
+        bool result = sale.auctionToken.approve(address(vesting.vestingContract), sale.salesAmount);
         if (!result) {
             revert ApprovalFailed();
         }

--- a/src/crowdsale/VestedCrowdSale.sol
+++ b/src/crowdsale/VestedCrowdSale.sol
@@ -90,9 +90,10 @@ contract VestedCrowdSale is CrowdSale {
 
         IERC20(_sales[saleId].auctionToken).safeTransfer(address(vesting.vestingContract), auctionTokens);
 
-        //todo: find out from where we want to count the vesting cliff time: opening time, settlement time or claiming time
+        //the vesting start time is the official auction closing time
+        //https://discord.com/channels/608198475598790656/1021413298756923462/1107442747687829515
         vesting.vestingContract.createVestingSchedule(
-            msg.sender, _sales[saleId].openingTime, vesting.cliff, vesting.duration, 60, false, auctionTokens
+            msg.sender, _sales[saleId].closingTime, vesting.cliff, vesting.duration, 60, false, auctionTokens
         );
     }
 }

--- a/subgraph/abis/StakedVestedCrowdSale.json
+++ b/subgraph/abis/StakedVestedCrowdSale.json
@@ -11,11 +11,6 @@
   },
   {
     "inputs": [],
-    "name": "BadSaleDuration",
-    "type": "error"
-  },
-  {
-    "inputs": [],
     "name": "BalanceTooLow",
     "type": "error"
   },
@@ -121,6 +116,19 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "saleId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Failed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": true,
         "internalType": "uint256",
         "name": "saleId",
@@ -185,9 +193,9 @@
             "type": "uint256"
           },
           {
-            "internalType": "uint256",
+            "internalType": "uint64",
             "name": "closingTime",
-            "type": "uint256"
+            "type": "uint64"
           }
         ],
         "indexed": false,
@@ -293,9 +301,9 @@
             "type": "uint256"
           },
           {
-            "internalType": "uint256",
+            "internalType": "uint64",
             "name": "closingTime",
-            "type": "uint256"
+            "type": "uint64"
           }
         ],
         "indexed": false,
@@ -373,9 +381,9 @@
             "type": "uint256"
           },
           {
-            "internalType": "uint256",
+            "internalType": "uint64",
             "name": "closingTime",
-            "type": "uint256"
+            "type": "uint64"
           }
         ],
         "indexed": false,
@@ -466,9 +474,9 @@
       {
         "components": [
           {
-            "internalType": "bool",
-            "name": "settled",
-            "type": "bool"
+            "internalType": "enum SaleState",
+            "name": "state",
+            "type": "uint8"
           },
           {
             "internalType": "uint256",
@@ -619,9 +627,146 @@
             "type": "uint256"
           },
           {
-            "internalType": "uint256",
+            "internalType": "uint64",
             "name": "closingTime",
+            "type": "uint64"
+          }
+        ],
+        "internalType": "struct Sale",
+        "name": "sale",
+        "type": "tuple"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "stakedToken",
+        "type": "address"
+      },
+      {
+        "internalType": "contract TokenVesting",
+        "name": "stakesVesting",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "wadFixedDaoPerBidPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "cliff",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "duration",
+        "type": "uint256"
+      }
+    ],
+    "name": "startSale",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "saleId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IERC20Metadata",
+            "name": "auctionToken",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "biddingToken",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "beneficiary",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "fundingGoal",
             "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "salesAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint64",
+            "name": "closingTime",
+            "type": "uint64"
+          }
+        ],
+        "internalType": "struct Sale",
+        "name": "sale",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "cliff",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "duration",
+        "type": "uint256"
+      }
+    ],
+    "name": "startSale",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "saleId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IERC20Metadata",
+            "name": "auctionToken",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "biddingToken",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "beneficiary",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "fundingGoal",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "salesAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint64",
+            "name": "closingTime",
+            "type": "uint64"
           }
         ],
         "internalType": "struct Sale",
@@ -707,9 +852,60 @@
             "type": "uint256"
           },
           {
-            "internalType": "uint256",
+            "internalType": "uint64",
             "name": "closingTime",
+            "type": "uint64"
+          }
+        ],
+        "internalType": "struct Sale",
+        "name": "sale",
+        "type": "tuple"
+      }
+    ],
+    "name": "startSale",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "saleId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "contract IERC20Metadata",
+            "name": "auctionToken",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "biddingToken",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "beneficiary",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "fundingGoal",
             "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "salesAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint64",
+            "name": "closingTime",
+            "type": "uint64"
           }
         ],
         "internalType": "struct Sale",
@@ -736,194 +932,6 @@
         ],
         "internalType": "struct VestingConfig",
         "name": "vesting",
-        "type": "tuple"
-      }
-    ],
-    "name": "startSale",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "saleId",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "components": [
-          {
-            "internalType": "contract IERC20Metadata",
-            "name": "auctionToken",
-            "type": "address"
-          },
-          {
-            "internalType": "contract IERC20",
-            "name": "biddingToken",
-            "type": "address"
-          },
-          {
-            "internalType": "address",
-            "name": "beneficiary",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "fundingGoal",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "salesAmount",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "closingTime",
-            "type": "uint256"
-          }
-        ],
-        "internalType": "struct Sale",
-        "name": "sale",
-        "type": "tuple"
-      },
-      {
-        "internalType": "contract IERC20",
-        "name": "stakedToken",
-        "type": "address"
-      },
-      {
-        "internalType": "contract TokenVesting",
-        "name": "stakesVesting",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "wadFixedDaoPerBidPrice",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "cliff",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "duration",
-        "type": "uint256"
-      }
-    ],
-    "name": "startSale",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "saleId",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "components": [
-          {
-            "internalType": "contract IERC20Metadata",
-            "name": "auctionToken",
-            "type": "address"
-          },
-          {
-            "internalType": "contract IERC20",
-            "name": "biddingToken",
-            "type": "address"
-          },
-          {
-            "internalType": "address",
-            "name": "beneficiary",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "fundingGoal",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "salesAmount",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "closingTime",
-            "type": "uint256"
-          }
-        ],
-        "internalType": "struct Sale",
-        "name": "sale",
-        "type": "tuple"
-      },
-      {
-        "internalType": "uint256",
-        "name": "cliff",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "duration",
-        "type": "uint256"
-      }
-    ],
-    "name": "startSale",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "saleId",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "components": [
-          {
-            "internalType": "contract IERC20Metadata",
-            "name": "auctionToken",
-            "type": "address"
-          },
-          {
-            "internalType": "contract IERC20",
-            "name": "biddingToken",
-            "type": "address"
-          },
-          {
-            "internalType": "address",
-            "name": "beneficiary",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "fundingGoal",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "salesAmount",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "closingTime",
-            "type": "uint256"
-          }
-        ],
-        "internalType": "struct Sale",
-        "name": "sale",
         "type": "tuple"
       }
     ],

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -91,6 +91,13 @@ type Mintpass @entity {
   status: MintpassStatus
 }
 
+enum SaleState {
+  UNKNOWN
+  RUNNING
+  SETTLED
+  FAILED
+}
+
 type CrowdSale @entity {
   id: ID!
   fractionalizedIpnft: Fractionalized!
@@ -98,7 +105,7 @@ type CrowdSale @entity {
   beneficiary: Bytes! #address of the receiver of fundingGoal (usually issuer)
   closingTime: BigInt! #the time when the auction ends
   createdAt: BigInt! #the time when the auction was created
-  settled: Boolean! #true if the fundingGoal has been reached
+  state: SaleState!
   auctionToken: ERC20Token # could also use FractionalizedToken
   salesAmount: BigInt! #the amount of tokens to be auctioned
   vestedAuctionToken: ERC20Token #the vested auction token that bidders partially receive when claiming
@@ -107,9 +114,9 @@ type CrowdSale @entity {
   fundingGoal: BigInt! #the amount of tokens to be raised
   amountRaised: BigInt! #the amount of tokens raised so far
   stakingToken: ERC20Token
-  amountStaked: BigInt #the amount of tokens staked so far
+  amountStaked: BigInt! #the amount of tokens staked so far
   vestedStakingToken: ERC20Token #the vested staking token that bidders partially receive after claiming
-  stakingCliff: BigInt # The staking token cliff
+  stakingCliff: BigInt! # The staking token cliff
   #type: String! #the type of auction, can be "basic", "vested" "stakedVested"
 
   contributions: [Contribution!] @derivedFrom(field: "crowdSale")

--- a/subgraph/subgraph.template.yaml
+++ b/subgraph/subgraph.template.yaml
@@ -125,7 +125,7 @@ dataSources:
         - name: IERC20Metadata
           file: ./abis/IERC20Metadata.json
       eventHandlers:
-        - event: Started(uint256,indexed address,(address,address,address,uint256,uint256,uint256),(address,uint256,uint256),(address,address,uint256,uint256))
+        - event: Started(uint256,indexed address,(address,address,address,uint256,uint256,uint64),(address,uint256,uint256),(address,address,uint256,uint256))
           handler: handleStarted
         - event: Settled(indexed uint256,uint256,uint256)
           handler: handleSettled
@@ -133,6 +133,8 @@ dataSources:
           handler: handleClaimed
         - event: Bid(indexed uint256,indexed address,uint256,uint256,uint256)
           handler: handleBid
+        - event: Failed(uint256)
+          handler: handleFailed
       file: ./src/stakedVestedCrowdSaleMapping.ts
   - kind: ethereum
     name: TermsAcceptedPermissioner

--- a/test/CrowdSale.t.sol
+++ b/test/CrowdSale.t.sol
@@ -6,7 +6,7 @@ import "forge-std/console.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
-import { CrowdSale, Sale, SaleInfo, BadSaleDuration, BalanceTooLow, SaleAlreadyActive } from "../src/crowdsale/CrowdSale.sol";
+import { CrowdSale, SaleState, Sale, SaleInfo, BadSaleDuration, BalanceTooLow, SaleAlreadyActive } from "../src/crowdsale/CrowdSale.sol";
 import { FakeERC20 } from "./helpers/FakeERC20.sol";
 import { CrowdSaleHelpers } from "./helpers/CrowdSaleHelpers.sol";
 
@@ -112,6 +112,36 @@ contract CrowdSaleTest is Test {
         vm.stopPrank();
 
         assertEq(auctionToken.balanceOf(bidder), _sale.salesAmount);
+    }
+
+    function testUnsuccessfulSaleClaims() public {
+        vm.startPrank(emitter);
+        Sale memory _sale = CrowdSaleHelpers.makeSale(auctionToken, biddingToken);
+        auctionToken.approve(address(crowdSale), 400_000 ether);
+        uint256 saleId = crowdSale.startSale(_sale);
+        vm.stopPrank();
+
+        vm.startPrank(bidder);
+        crowdSale.placeBid(saleId, 150_000 ether);
+        vm.stopPrank();
+
+        vm.startPrank(anyone);
+        vm.warp(block.timestamp + 3 hours);
+        crowdSale.settle(saleId);
+        vm.stopPrank();
+
+        assertEq(biddingToken.balanceOf(emitter), 0);
+        assertEq(auctionToken.balanceOf(emitter), 500_000 ether);
+        SaleInfo memory info = crowdSale.saleInfo(saleId);
+        assertEq(info.surplus, 0);
+        assertEq(uint256(info.state), uint256(SaleState.FAILED));
+
+        vm.startPrank(bidder);
+        crowdSale.claim(saleId);
+        vm.stopPrank();
+
+        assertEq(biddingToken.balanceOf(bidder), 1_000_000 ether);
+        assertEq(auctionToken.balanceOf(bidder), 0);
     }
 
     function testTwoBiddersMeetExactly() public {

--- a/test/CrowdSale.t.sol
+++ b/test/CrowdSale.t.sol
@@ -116,7 +116,7 @@ contract CrowdSaleTest is Test {
 
     function testUnsuccessfulSaleClaims() public {
         vm.startPrank(emitter);
-        Sale memory _sale = CrowdSaleHelpers.makeSale(auctionToken, biddingToken);
+        Sale memory _sale = CrowdSaleHelpers.makeSale(emitter, auctionToken, biddingToken);
         auctionToken.approve(address(crowdSale), 400_000 ether);
         uint256 saleId = crowdSale.startSale(_sale);
         vm.stopPrank();

--- a/test/CrowdSale.t.sol
+++ b/test/CrowdSale.t.sol
@@ -96,6 +96,10 @@ contract CrowdSaleTest is Test {
         vm.stopPrank();
 
         vm.startPrank(anyone);
+        vm.expectRevert("sale has not concluded yet");
+        crowdSale.settle(saleId);
+
+        vm.warp(block.timestamp + 3 hours);
         crowdSale.settle(saleId);
         vm.stopPrank();
 
@@ -126,6 +130,7 @@ contract CrowdSaleTest is Test {
         vm.stopPrank();
 
         vm.startPrank(anyone);
+        vm.warp(block.timestamp + 3 hours);
         crowdSale.settle(saleId);
         vm.stopPrank();
 
@@ -154,6 +159,7 @@ contract CrowdSaleTest is Test {
         assertEq(biddingToken.balanceOf(bidder), 0);
 
         vm.startPrank(anyone);
+        vm.warp(block.timestamp + 3 hours);
         crowdSale.settle(saleId);
         vm.stopPrank();
 
@@ -204,6 +210,7 @@ contract CrowdSaleTest is Test {
         // vm.stopPrank();
 
         vm.startPrank(anyone);
+        vm.warp(block.timestamp + 3 hours);
         crowdSale.settle(saleId);
         vm.stopPrank();
 
@@ -264,6 +271,7 @@ contract CrowdSaleTest is Test {
         */
 
         vm.startPrank(anyone);
+        vm.warp(block.timestamp + 3 hours);
         crowdSale.settle(saleId);
         vm.stopPrank();
 

--- a/test/CrowdSaleFuzz.t.sol
+++ b/test/CrowdSaleFuzz.t.sol
@@ -40,7 +40,8 @@ contract CrowdSaleFuzzTest is Test {
             biddingToken: IERC20(address(biddingToken)),
             fundingGoal: fundingGoal,
             salesAmount: salesAmt,
-            closingTime: block.timestamp + 2 hours
+            openingTime: uint64(block.timestamp),
+            closingTime: uint64(block.timestamp + 2 hours)
         });
 
         auctionToken.approve(address(crowdSale), salesAmt);

--- a/test/CrowdSaleFuzz.t.sol
+++ b/test/CrowdSaleFuzz.t.sol
@@ -40,7 +40,6 @@ contract CrowdSaleFuzzTest is Test {
             biddingToken: IERC20(address(biddingToken)),
             fundingGoal: fundingGoal,
             salesAmount: salesAmt,
-            openingTime: uint64(block.timestamp),
             closingTime: uint64(block.timestamp + 2 hours)
         });
 

--- a/test/CrowdSaleVested.t.sol
+++ b/test/CrowdSaleVested.t.sol
@@ -55,6 +55,7 @@ contract CrowdSaleVestedTest is Test {
         vm.stopPrank();
 
         vm.startPrank(anyone);
+        vm.warp(block.timestamp + 3 hours);
         crowdSale.settle(saleId);
         vm.stopPrank();
 
@@ -78,7 +79,7 @@ contract CrowdSaleVestedTest is Test {
 
         vm.warp(genesis + 60 days);
         auctionTokenVesting.releaseAvailableTokensForHolder(bidder);
-        assertTrue(auctionToken.balanceOf(bidder) > 65_000 ether);
+        assertGt(auctionToken.balanceOf(bidder), 65_000 ether);
 
         vm.warp(genesis + 366 days);
         auctionTokenVesting.releaseAvailableTokensForHolder(bidder);

--- a/test/CrowdSaleVested.t.sol
+++ b/test/CrowdSaleVested.t.sol
@@ -6,7 +6,7 @@ import "forge-std/console.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
-import { CrowdSale, Sale, SaleInfo } from "../src/crowdsale/CrowdSale.sol";
+import { CrowdSale, SaleState, Sale, SaleInfo } from "../src/crowdsale/CrowdSale.sol";
 import { VestedCrowdSale, VestingConfig } from "../src/crowdsale/VestedCrowdSale.sol";
 import { TokenVesting } from "@moleculeprotocol/token-vesting/TokenVesting.sol";
 import { FakeERC20 } from "./helpers/FakeERC20.sol";
@@ -86,5 +86,39 @@ contract CrowdSaleVestedTest is Test {
         assertEq(auctionToken.balanceOf(bidder), _sale.salesAmount);
         assertEq(auctionTokenVesting.balanceOf(bidder), 0);
         vm.stopPrank();
+    }
+
+    function testUnsuccessfulSaleClaims() public {
+        vm.startPrank(emitter);
+        Sale memory _sale = CrowdSaleHelpers.makeSale(auctionToken, biddingToken);
+        auctionToken.approve(address(crowdSale), 400_000 ether);
+        uint256 saleId = crowdSale.startSale(_sale, 60 days, 365 days);
+
+        vm.stopPrank();
+
+        vm.startPrank(bidder);
+        crowdSale.placeBid(saleId, 150_000 ether);
+        vm.stopPrank();
+
+        vm.startPrank(anyone);
+        vm.warp(block.timestamp + 3 hours);
+        crowdSale.settle(saleId);
+        vm.stopPrank();
+
+        assertEq(biddingToken.balanceOf(emitter), 0);
+        assertEq(auctionToken.balanceOf(emitter), 500_000 ether);
+        SaleInfo memory info = crowdSale.saleInfo(saleId);
+        assertEq(info.surplus, 0);
+        assertEq(uint256(info.state), uint256(SaleState.FAILED));
+
+        vm.startPrank(bidder);
+        crowdSale.claim(saleId);
+        vm.stopPrank();
+
+        assertEq(biddingToken.balanceOf(bidder), 1_000_000 ether);
+        assertEq(auctionToken.balanceOf(bidder), 0);
+        (TokenVesting auctionTokenVesting,,) = crowdSale.salesVesting(saleId);
+
+        assertEq(auctionTokenVesting.balanceOf(bidder), 0);
     }
 }

--- a/test/CrowdSaleVested.t.sol
+++ b/test/CrowdSaleVested.t.sol
@@ -42,8 +42,6 @@ contract CrowdSaleVestedTest is Test {
     }
 
     function testSettlementAndSimpleClaims() public {
-        uint256 genesis = block.timestamp;
-
         vm.startPrank(emitter);
         Sale memory _sale = CrowdSaleHelpers.makeSale(emitter, auctionToken, biddingToken);
         auctionToken.approve(address(crowdSale), 400_000 ether);
@@ -72,16 +70,16 @@ contract CrowdSaleVestedTest is Test {
         assertEq(auctionTokenVesting.balanceOf(bidder), _sale.salesAmount);
 
         vm.startPrank(bidder);
-        vm.warp(genesis + 10 days);
+        vm.warp(_sale.closingTime + 10 days);
         auctionTokenVesting.releaseAvailableTokensForHolder(bidder);
         assertEq(auctionTokenVesting.balanceOf(bidder), _sale.salesAmount);
         assertEq(auctionToken.balanceOf(bidder), 0);
 
-        vm.warp(genesis + 60 days);
+        vm.warp(_sale.closingTime + 60 days);
         auctionTokenVesting.releaseAvailableTokensForHolder(bidder);
         assertGt(auctionToken.balanceOf(bidder), 65_000 ether);
 
-        vm.warp(genesis + 366 days);
+        vm.warp(_sale.closingTime + 366 days);
         auctionTokenVesting.releaseAvailableTokensForHolder(bidder);
         assertEq(auctionToken.balanceOf(bidder), _sale.salesAmount);
         assertEq(auctionTokenVesting.balanceOf(bidder), 0);
@@ -90,7 +88,7 @@ contract CrowdSaleVestedTest is Test {
 
     function testUnsuccessfulSaleClaims() public {
         vm.startPrank(emitter);
-        Sale memory _sale = CrowdSaleHelpers.makeSale(auctionToken, biddingToken);
+        Sale memory _sale = CrowdSaleHelpers.makeSale(emitter, auctionToken, biddingToken);
         auctionToken.approve(address(crowdSale), 400_000 ether);
         uint256 saleId = crowdSale.startSale(_sale, 60 days, 365 days);
 

--- a/test/CrowdSaleVestedStaked.t.sol
+++ b/test/CrowdSaleVestedStaked.t.sol
@@ -91,6 +91,7 @@ contract CrowdSaleVestedStakedTest is Test {
         assertEq(daoToken.balanceOf(address(crowdSale)), 200_000 ether);
 
         vm.startPrank(anyone);
+        vm.warp(block.timestamp + 3 hours);
         crowdSale.settle(saleId);
         vm.stopPrank();
 
@@ -179,6 +180,7 @@ contract CrowdSaleVestedStakedTest is Test {
 
         */
         vm.startPrank(anyone);
+        vm.warp(block.timestamp + 3 hours);
         crowdSale.settle(saleId);
         vm.stopPrank();
 
@@ -238,6 +240,7 @@ contract CrowdSaleVestedStakedTest is Test {
         assertEq(crowdSale.stakesOf(saleId, bidder2), 112_500 ether);
 
         vm.startPrank(anyone);
+        vm.warp(block.timestamp + 3 hours);
         crowdSale.settle(saleId);
         vm.stopPrank();
 

--- a/test/CrowdSaleVestedStaked.t.sol
+++ b/test/CrowdSaleVestedStaked.t.sol
@@ -271,7 +271,7 @@ contract CrowdSaleVestedStakedTest is Test {
 
     function testUnsuccessfulSaleClaims() public {
         vm.startPrank(emitter);
-        Sale memory _sale = CrowdSaleHelpers.makeSale(auctionToken, biddingToken);
+        Sale memory _sale = CrowdSaleHelpers.makeSale(emitter, auctionToken, biddingToken);
         auctionToken.approve(address(crowdSale), 400_000 ether);
         uint256 saleId = crowdSale.startSale(_sale, daoToken, vestedDao, 25e16, 60 days, 365 days);
 

--- a/test/helpers/CrowdSaleHelpers.sol
+++ b/test/helpers/CrowdSaleHelpers.sol
@@ -14,7 +14,6 @@ library CrowdSaleHelpers {
             biddingToken: IERC20(address(biddingToken)),
             fundingGoal: 200_000 ether,
             salesAmount: 400_000 ether,
-            openingTime: uint64(block.timestamp),
             closingTime: uint64(block.timestamp + 2 hours)
         });
     }

--- a/test/helpers/CrowdSaleHelpers.sol
+++ b/test/helpers/CrowdSaleHelpers.sol
@@ -14,7 +14,8 @@ library CrowdSaleHelpers {
             biddingToken: IERC20(address(biddingToken)),
             fundingGoal: 200_000 ether,
             salesAmount: 400_000 ether,
-            closingTime: block.timestamp + 2 hours
+            openingTime: uint64(block.timestamp),
+            closingTime: uint64(block.timestamp + 2 hours)
         });
     }
 }


### PR DESCRIPTION
- a sale is failed when the funding goal hasn't been reached after ending time
- reuses settle code for all contracts
- failed sales are identified on the common `settle` method
- dedicated claim method behaviour that returns contributions after a sale is marked as failed
- script can't claim immediately. added a helper output variable and script to claim sale manually afterwards
