### PR TITLE
support for non-18 decimals bidding tokens / fixes double claim issues

### DIFF
--- a/src/BioPriceFeed.sol
+++ b/src/BioPriceFeed.sol
@@ -48,17 +48,17 @@ contract BioPriceFeed is IPriceFeedConsumer, AccessControl {
 
     function getPrice(address base, address quote) external view returns (uint184) {
         bytes32 key = keccak256(abi.encode(base, quote));
-        if (meta[key].decimals != 0) {
-            if (meta[key].decimals > 18) revert("unsupported");
-            return uint184(signals[key].rate / 10 ** (18 - meta[key].decimals));
-        } else {
-            return signals[key].rate;
-        }
+        return signals[key].rate;
+        // if (meta[key].decimals != 0) {
+        //     if (meta[key].decimals > 18) revert("unsupported");
+        //     return uint184(signals[key].rate / 10 ** (18 - meta[key].decimals));
+        // } else {
+        // }
     }
 
-    function setMetadata(address base, address quote, Meta calldata _meta) external onlyRole(ROLE_SIGNALLER) {
-        meta[keccak256(abi.encode(base, quote))] = _meta;
-    }
+    // function setMetadata(address base, address quote, Meta calldata _meta) external onlyRole(ROLE_SIGNALLER) {
+    //     meta[keccak256(abi.encode(base, quote))] = _meta;
+    // }
 
     function signal(address base, address quote, uint184 wadPrice) external onlyRole(ROLE_SIGNALLER) {
         signals[keccak256(abi.encode(base, quote))] = Signal(wadPrice, uint64(block.timestamp));

--- a/src/crowdsale/CrowdSale.sol
+++ b/src/crowdsale/CrowdSale.sol
@@ -18,7 +18,7 @@ enum SaleState {
 
 struct Sale {
     IERC20Metadata auctionToken;
-    IERC20 biddingToken;
+    IERC20Metadata biddingToken;
     address beneficiary;
     //how many bidding tokens to collect
     uint256 fundingGoal;
@@ -65,14 +65,15 @@ contract CrowdSale {
         if (sale.closingTime < block.timestamp) {
             revert BadSaleDuration();
         }
-        if (sale.auctionToken.decimals() != 18 || IERC20Metadata(address(sale.biddingToken)).decimals() != 18) {
+        //|| IERC20Metadata(address(sale.biddingToken)).decimals() != 18
+        if (sale.auctionToken.decimals() != 18) {
             revert BadDecimals();
         }
         if (sale.auctionToken.balanceOf(msg.sender) < sale.salesAmount) {
             revert BalanceTooLow();
         }
         //close to 0 cases lead to very confusing results
-        if (sale.fundingGoal < 0.5 ether || sale.salesAmount < 0.5 ether) {
+        if (sale.fundingGoal < 1 * 10 ** sale.biddingToken.decimals() || sale.salesAmount < 0.5 ether) {
             revert BadSalesAmount();
         }
         if (sale.beneficiary == address(0)) {

--- a/src/crowdsale/CrowdSale.sol
+++ b/src/crowdsale/CrowdSale.sol
@@ -88,14 +88,24 @@ contract CrowdSale {
         _saleInfo[saleId] = SaleInfo(SaleState.RUNNING, 0, 0);
 
         sale.auctionToken.safeTransferFrom(msg.sender, address(this), sale.salesAmount);
-        _onSaleStarted(saleId);
+        _afterSaleStarted(saleId);
+    }
+
+    function saleInfo(uint256 saleId) public view returns (SaleInfo memory) {
+        return _saleInfo[saleId];
     }
 
     function placeBid(uint256 saleId, uint256 biddingTokenAmount) public virtual {
         return placeBid(saleId, biddingTokenAmount, bytes(""));
     }
 
-    function placeBid(uint256 saleId, uint256 biddingTokenAmount, bytes memory permission) public virtual {
+    /**
+     * @dev even though `auctionToken` is casted to `FractionalizedToken` this should still work with IPNFT agnostic tokens
+     * @param saleId the sale id
+     * @param biddingTokenAmount the amount of bidding tokens
+     * @param permission bytes are handed over to a configured permissioner contract
+     */
+    function placeBid(uint256 saleId, uint256 biddingTokenAmount, bytes memory permission) public {
         if (biddingTokenAmount == 0) {
             revert("must bid something");
         }
@@ -116,10 +126,14 @@ contract CrowdSale {
         _bid(saleId, biddingTokenAmount);
     }
 
+    function contribution(uint256 saleId, address contributor) public view returns (uint256) {
+        return _contributions[saleId][contributor];
+    }
     /**
-     * @notice anyone can call this for the beneficiary
+     * @notice anyone can call this for the beneficiary. Releases raised funds to beneficiary when funding goal was met
      * @param saleId the sale id
      */
+
     function settle(uint256 saleId) public virtual {
         Sale memory sale = _sales[saleId];
         SaleInfo storage __saleInfo = _saleInfo[saleId];
@@ -143,9 +157,17 @@ contract CrowdSale {
         emit Settled(saleId, __saleInfo.total, __saleInfo.surplus);
 
         //transfer funds to issuer / beneficiary
-        release(sale.biddingToken, sale.beneficiary, sale.fundingGoal);
+        sale.biddingToken.safeTransfer(sale.beneficiary, sale.fundingGoal);
     }
 
+    /**
+     * @dev computes commitment ratio of bidder
+     *
+     * @param saleId sale id
+     * @param bidder bidder
+     * @return auctionTokens wei value of auction tokens to return
+     * @return refunds wei value of bidding tokens to return
+     */
     function getClaimableAmounts(uint256 saleId, address bidder) public view virtual returns (uint256 auctionTokens, uint256 refunds) {
         uint256 _contribution = _contributions[saleId][bidder];
         uint256 fundingGoal = _sales[saleId].fundingGoal;
@@ -166,6 +188,12 @@ contract CrowdSale {
         return claim(saleId, bytes(""));
     }
 
+    /**
+     * @dev even though `auctionToken` is casted to `FractionalizedToken` this should still work with IPNFT agnostic tokens
+     * @notice public method that refunds and lets user redeem their sales shares
+     * @param saleId the sale id
+     * @param permission. bytes are handed over to a configured permissioner contract
+     */
     function claim(uint256 saleId, bytes memory permission) public returns (uint256 auctionTokens, uint256 refunds) {
         if (_saleInfo[saleId].state == SaleState.RUNNING) {
             revert("sale is not settled");
@@ -177,27 +205,42 @@ contract CrowdSale {
             _sales[saleId].permissioner.accept(FractionalizedToken(address(_sales[saleId].auctionToken)), msg.sender, permission);
         }
         (auctionTokens, refunds) = getClaimableAmounts(saleId, msg.sender);
+        //a reentrancy won't have any effect after this.
+        _contributions[saleId][msg.sender] = 0;
         claim(saleId, auctionTokens, refunds);
     }
 
-    function claim(uint256 saleId, uint256 auctionTokens, uint256 refunds) internal virtual {
-        emit Claimed(saleId, msg.sender, auctionTokens, refunds);
+    /**
+     * @notice will send `tokenAmount` auction tokens to the bidder
+     *
+     * @param saleId sale id
+     * @param tokenAmount amount of tokens to vest
+     * @param refunds biddingtTokens to refund
+     */
+    function claim(uint256 saleId, uint256 tokenAmount, uint256 refunds) internal virtual {
+        //the sender has claimed already
+        if (tokenAmount == 0) {
+            return;
+        }
+        emit Claimed(saleId, msg.sender, tokenAmount, refunds);
 
         if (refunds > 0) {
             _sales[saleId].biddingToken.safeTransfer(msg.sender, refunds);
         }
-        _sales[saleId].auctionToken.safeTransfer(msg.sender, auctionTokens);
+        _claimAuctionTokens(saleId, tokenAmount);
     }
 
-    function saleInfo(uint256 saleId) public view returns (SaleInfo memory) {
-        return _saleInfo[saleId];
+    /**
+     * @dev overridden in VestedCrowdSale (will lock auction tokens in vested contract)
+     */
+    function _claimAuctionTokens(uint256 saleId, uint256 tokenAmount) internal virtual {
+        _sales[saleId].auctionToken.safeTransfer(msg.sender, tokenAmount);
     }
 
-    function contribution(uint256 saleId, address contributor) public view returns (uint256) {
-        return _contributions[saleId][contributor];
-    }
-
-    function _onSaleStarted(uint256 saleId) internal virtual {
+    /**
+     * @dev allows us to emit different events per derived contract
+     */
+    function _afterSaleStarted(uint256 saleId) internal virtual {
         emit Started(saleId, msg.sender, _sales[saleId]);
     }
 
@@ -220,12 +263,7 @@ contract CrowdSale {
         IERC20 biddingToken = _sales[saleId].biddingToken;
         _saleInfo[saleId].total += biddingTokenAmount;
         _contributions[saleId][msg.sender] += biddingTokenAmount;
-
         biddingToken.safeTransferFrom(msg.sender, address(this), biddingTokenAmount);
         emit Bid(saleId, msg.sender, biddingTokenAmount);
-    }
-
-    function release(IERC20 biddingToken, address beneficiary, uint256 fundingGoal) internal virtual {
-        biddingToken.safeTransfer(beneficiary, fundingGoal);
     }
 }

--- a/src/crowdsale/StakedVestedCrowdSale.sol
+++ b/src/crowdsale/StakedVestedCrowdSale.sol
@@ -73,12 +73,12 @@ contract StakedVestedCrowdSale is VestedCrowdSale {
         super.startSale(sale, vestingConfig);
     }
 
-    function _onSaleStarted(uint256 saleId) internal virtual override {
-        emit Started(saleId, msg.sender, _sales[saleId], salesVesting[saleId], salesStaking[saleId]);
-    }
-
     function stakesOf(uint256 saleId, address bidder) public view returns (uint256) {
         return stakes[saleId][bidder];
+    }
+
+    function _onSaleStarted(uint256 saleId) internal virtual override {
+        emit Started(saleId, msg.sender, _sales[saleId], salesVesting[saleId], salesStaking[saleId]);
     }
 
     function settle(uint256 saleId) public override {

--- a/src/crowdsale/VestedCrowdSale.sol
+++ b/src/crowdsale/VestedCrowdSale.sol
@@ -73,7 +73,7 @@ contract VestedCrowdSale is CrowdSale {
         saleId = super.startSale(sale);
     }
 
-    function _onSaleStarted(uint256 saleId) internal virtual override {
+    function _afterSaleStarted(uint256 saleId) internal virtual override {
         emit Started(saleId, msg.sender, _sales[saleId], salesVesting[saleId]);
     }
 
@@ -84,8 +84,7 @@ contract VestedCrowdSale is CrowdSale {
         }
 
         Sale memory sale = _sales[saleId];
-        VestingConfig memory vesting = salesVesting[saleId];
-        bool result = sale.auctionToken.approve(address(vesting.vestingContract), sale.salesAmount);
+        bool result = sale.auctionToken.approve(address(salesVesting[saleId].vestingContract), sale.salesAmount);
         if (!result) {
             revert ApprovalFailed();
         }
@@ -96,15 +95,9 @@ contract VestedCrowdSale is CrowdSale {
      *
      * @param saleId sale id
      * @param tokenAmount amount of tokens to vest
-     * @param refunds unvested tokens to be returned
      */
-    function claim(uint256 saleId, uint256 tokenAmount, uint256 refunds) internal virtual override {
+    function _claimAuctionTokens(uint256 saleId, uint256 tokenAmount) internal virtual override {
         VestingConfig memory vesting = salesVesting[saleId];
-        if (refunds > 0) {
-            _sales[saleId].biddingToken.safeTransfer(msg.sender, refunds);
-        }
-
-        emit Claimed(saleId, msg.sender, tokenAmount, refunds);
 
         //the vesting start time is the official auction closing time
         //https://discord.com/channels/608198475598790656/1021413298756923462/1107442747687829515

--- a/src/crowdsale/VestedCrowdSale.sol
+++ b/src/crowdsale/VestedCrowdSale.sol
@@ -31,7 +31,7 @@ error IncompatibleVestingContract();
  * @notice puts the sold tokens under a configured vesting scheme
  */
 contract VestedCrowdSale is CrowdSale {
-    using SafeERC20 for IERC20;
+    using SafeERC20 for IERC20Metadata;
 
     mapping(uint256 => VestingConfig) public salesVesting;
 
@@ -110,9 +110,9 @@ contract VestedCrowdSale is CrowdSale {
         //https://discord.com/channels/608198475598790656/1021413298756923462/1107442747687829515
         if (block.timestamp > _sales[saleId].closingTime + vesting.cliff) {
             //no need for vesting when cliff already expired.
-            IERC20(_sales[saleId].auctionToken).safeTransfer(msg.sender, tokenAmount);
+            _sales[saleId].auctionToken.safeTransfer(msg.sender, tokenAmount);
         } else {
-            IERC20(_sales[saleId].auctionToken).safeTransfer(address(vesting.vestingContract), tokenAmount);
+            _sales[saleId].auctionToken.safeTransfer(address(vesting.vestingContract), tokenAmount);
             vesting.vestingContract.createVestingSchedule(
                 msg.sender, _sales[saleId].closingTime, vesting.cliff, vesting.cliff, 60, false, tokenAmount
             );

--- a/test/CrowdSale.t.sol
+++ b/test/CrowdSale.t.sol
@@ -72,7 +72,7 @@ contract CrowdSaleTest is Test {
         vm.startPrank(emitter);
         Sale memory _sale = Sale({
             auctionToken: IERC20Metadata(address(0)),
-            biddingToken: IERC20(address(0)),
+            biddingToken: IERC20Metadata(address(0)),
             beneficiary: address(0),
             fundingGoal: 0,
             salesAmount: 0,
@@ -91,7 +91,7 @@ contract CrowdSaleTest is Test {
         vm.expectRevert();
         crowdSale.startSale(_sale);
 
-        _sale.biddingToken = IERC20(address(biddingToken));
+        _sale.biddingToken = biddingToken;
         vm.expectRevert(BadSalesAmount.selector);
         crowdSale.startSale(_sale);
 

--- a/test/CrowdSale.t.sol
+++ b/test/CrowdSale.t.sol
@@ -205,11 +205,17 @@ contract CrowdSaleTest is Test {
         crowdSale.settle(saleId);
         vm.stopPrank();
 
-        vm.startPrank(bidder);
-        crowdSale.claim(saleId);
+        vm.startPrank(bidder2);
+        (uint256 auctionTokens, uint256 refunds) = crowdSale.claim(saleId);
+        assertEq(auctionTokens, 100_000 ether);
+        assertEq(refunds, 0);
+        //a bidder can call this as often as they want, but they won't get anything
+        (auctionTokens, refunds) = crowdSale.claim(saleId);
+        assertEq(auctionTokens, 0);
+        assertEq(refunds, 0);
         vm.stopPrank();
 
-        vm.startPrank(bidder2);
+        vm.startPrank(bidder);
         crowdSale.claim(saleId);
         vm.stopPrank();
 
@@ -235,7 +241,13 @@ contract CrowdSaleTest is Test {
         vm.stopPrank();
 
         vm.startPrank(bidder);
-        crowdSale.claim(saleId);
+        (uint256 auctionTokens, uint256 refunds) = crowdSale.claim(saleId);
+        assertEq(auctionTokens, 400_000 ether);
+        assertEq(refunds, 800_000 ether);
+        //a bidder can call this as often as they want, but they won't get anything
+        (auctionTokens, refunds) = crowdSale.claim(saleId);
+        assertEq(auctionTokens, 0);
+        assertEq(refunds, 0);
         vm.stopPrank();
 
         assertEq(auctionToken.balanceOf(bidder), 400_000 ether);
@@ -285,12 +297,21 @@ contract CrowdSaleTest is Test {
         crowdSale.settle(saleId);
         vm.stopPrank();
 
-        vm.startPrank(bidder);
-        crowdSale.claim(saleId);
+        vm.startPrank(bidder2);
+        (uint256 auctionTokens, uint256 refunds) = crowdSale.claim(saleId);
+        assertEq(auctionTokens, 100_000 ether);
+        assertEq(refunds, 150_000 ether);
+        //a bidder can call this as often as they want, but they won't get anything
+        (auctionTokens, refunds) = crowdSale.claim(saleId);
+        assertEq(auctionTokens, 0);
+        assertEq(refunds, 0);
         vm.stopPrank();
 
-        vm.startPrank(bidder2);
+        vm.startPrank(bidder);
         crowdSale.claim(saleId);
+        (auctionTokens, refunds) = crowdSale.claim(saleId);
+        assertEq(auctionTokens, 0);
+        assertEq(refunds, 0);
         vm.stopPrank();
 
         assertEq(auctionToken.balanceOf(bidder), 300_000 ether);
@@ -346,11 +367,12 @@ contract CrowdSaleTest is Test {
         crowdSale.settle(saleId);
         vm.stopPrank();
 
-        vm.startPrank(bidder);
+        vm.startPrank(bidder2);
         crowdSale.claim(saleId);
+        crowdSale.claim(saleId); //just to ensure this doesn't have any effect
         vm.stopPrank();
 
-        vm.startPrank(bidder2);
+        vm.startPrank(bidder);
         crowdSale.claim(saleId);
         vm.stopPrank();
 

--- a/test/CrowdSaleFuzz.t.sol
+++ b/test/CrowdSaleFuzz.t.sol
@@ -30,7 +30,7 @@ contract CrowdSaleFuzzTest is Test {
     function testFuzzManyBidders(uint8 bidders, uint96 salesAmt, uint96 fundingGoal) public {
         vm.assume(bidders > 0 && bidders < 25);
         vm.assume(salesAmt > 0.5 ether);
-        vm.assume(fundingGoal > 0.5 ether);
+        vm.assume(fundingGoal > 1 ether);
 
         auctionToken.mint(emitter, salesAmt);
 
@@ -38,7 +38,7 @@ contract CrowdSaleFuzzTest is Test {
         Sale memory _sale = Sale({
             beneficiary: emitter,
             auctionToken: IERC20Metadata(address(auctionToken)),
-            biddingToken: IERC20(address(biddingToken)),
+            biddingToken: IERC20Metadata(address(biddingToken)),
             fundingGoal: fundingGoal,
             salesAmount: salesAmt,
             closingTime: uint64(block.timestamp + 2 hours),

--- a/test/CrowdSalePermissioned.t.sol
+++ b/test/CrowdSalePermissioned.t.sol
@@ -77,7 +77,7 @@ contract CrowdSalePermissionedTest is Test {
 
     function testPermissionedSettlementAndSimpleClaims() public {
         vm.startPrank(emitter);
-        Sale memory _sale = CrowdSaleHelpers.makeSale(emitter, IERC20(address(auctionToken)), biddingToken);
+        Sale memory _sale = CrowdSaleHelpers.makeSale(emitter, IERC20Metadata(address(auctionToken)), biddingToken);
         _sale.permissioner = permissioner;
         auctionToken.approve(address(crowdSale), 400_000 ether);
 

--- a/test/CrowdSaleVestedStaked.t.sol
+++ b/test/CrowdSaleVestedStaked.t.sol
@@ -222,12 +222,19 @@ contract CrowdSaleVestedStakedTest is Test {
         crowdSale.settle(saleId);
         vm.stopPrank();
 
+        vm.startPrank(bidder2);
+        crowdSale.claim(saleId);
+        (uint256 zeroTokens, uint256 zeroRefunds) = crowdSale.claim(saleId);
+        assertEq(zeroRefunds * zeroTokens, 0);
+        vm.stopPrank();
+
         vm.startPrank(bidder);
         crowdSale.claim(saleId);
         vm.stopPrank();
 
-        vm.startPrank(bidder2);
-        crowdSale.claim(saleId);
+        vm.startPrank(bidder2); //tries to "attack" by claiming once again
+        (zeroTokens, zeroRefunds) = crowdSale.claim(saleId);
+        assertEq(zeroRefunds * zeroTokens, 0);
         vm.stopPrank();
 
         (TokenVesting auctionTokenVesting,) = crowdSale.salesVesting(saleId);

--- a/test/CrowdSaleWithNonStandardERC20Test.sol
+++ b/test/CrowdSaleWithNonStandardERC20Test.sol
@@ -15,7 +15,10 @@ import { FakeERC20 } from "./helpers/FakeERC20.sol";
 //import { BioPriceFeed, IPriceFeedConsumer } from "../src/BioPriceFeed.sol";
 import { CrowdSaleHelpers } from "./helpers/CrowdSaleHelpers.sol";
 
-contract CrowdSaleVestedStaked6DecimalsTest is Test {
+/**
+ * @notice tests support for ERC20 with 6 decimals
+ */
+contract CrowdSaleWithNonStandardERC20Test is Test {
     address deployer = makeAddr("chucknorris");
     address emitter = makeAddr("emitter");
     address bidder = makeAddr("bidder");

--- a/test/helpers/CrowdSaleHelpers.sol
+++ b/test/helpers/CrowdSaleHelpers.sol
@@ -8,10 +8,10 @@ import { CrowdSale, Sale, SaleInfo, BadSaleDuration, BalanceTooLow, SaleAlreadyA
 import { IPermissioner } from "../../src/Permissioner.sol";
 
 library CrowdSaleHelpers {
-    function makeSale(address beneficiary, IERC20 auctionToken, IERC20 biddingToken) internal view returns (Sale memory sale) {
+    function makeSale(address beneficiary, IERC20Metadata auctionToken, IERC20Metadata biddingToken) internal view returns (Sale memory sale) {
         return Sale({
-            auctionToken: IERC20Metadata(address(auctionToken)),
-            biddingToken: IERC20(address(biddingToken)),
+            auctionToken: auctionToken,
+            biddingToken: biddingToken,
             beneficiary: beneficiary,
             fundingGoal: 200_000 ether,
             salesAmount: 400_000 ether,


### PR DESCRIPTION
- some official docs on price feeds' decimals: https://blog.openzeppelin.com/secure-smart-contract-guidelines-the-dangers-of-price-oracles/

- Chainlink Oracles also signal most prices with 18 decimals (the price itself is just a ratio, independent from any other precision): https://data.chain.link/ethereum/mainnet/stablecoins/usdc-eth (see `latestRoundData`: https://etherscan.io/address/0x986b5e1e1755e3c2440e960477f25201b0a8bbd4#readContract)

- I'm computing a precision adjusted price ratio when starting the sale. The user must always present a 18-digit price ratio.

- found a major flaw: bidders were able to claim more than once since we never reset their contribution or stakes registers. Fixed and tested that.


