### PR TITLE
Permissioned Synthesizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ IP-NFTs allow their users to tokenize intellectual property. This repo contains 
 - Subgraph: <https://api.thegraph.com/subgraphs/name/dorianwilhelm/ip-nft-subgraph-goerli/graphql>
 
 - Synthesizer: 0xb12494eeA6B992d0A1Db3C5423BE7a2d2337F58c  
-  (Impl no 1 0xbc255509707c5f95bab6b2f9189688300c5afa5f)
+  (Impl no 2 0x34dB200E2f1349AcEAb09e363d4e4631a68657f1)
+
   <https://goerli.etherscan.io/address/0xb12494eeA6B992d0A1Db3C5423BE7a2d2337F58c>
 
 - Terms Accepted Permissioner: 0x3aFb3D87c12239B4D9DB67837F4bE4651FbBEd20
@@ -39,6 +40,9 @@ IP-NFTs allow their users to tokenize intellectual property. This repo contains 
 
 - Staked/Locking Crowdsale: 0x5b161D131f8254A2df91e9382F6E5973aB4eD0f9
   <https://goerli.etherscan.io/address/0x5b161D131f8254A2df91e9382F6E5973aB4eD0f9#code>
+
+  - Blind Permissioner: 0xec68a1fc8d4c2834f8dfbdb56691f9f0a3d6be11
+    <https://goerli.etherscan.io/address/0xec68a1fc8d4c2834f8dfbdb56691f9f0a3d6be11#code>
 
 #### some test tokens
 

--- a/script/DeploySynthesizer.s.sol
+++ b/script/DeploySynthesizer.s.sol
@@ -24,7 +24,7 @@ contract DeploySynthesizerInfrastructure is Script {
                 )
             )
         );
-        synthesizer.initialize(IPNFT(ipnftAddress));
+        synthesizer.initialize(IPNFT(ipnftAddress), p);
 
         StakedLockingCrowdSale stakedLockingCrowdSale = new StakedLockingCrowdSale();
 

--- a/script/dev/Common.sol
+++ b/script/dev/Common.sol
@@ -15,11 +15,12 @@ contract CommonScript is Script {
     address anyone;
 
     uint256 alicePk;
+    uint256 bobPk;
     uint256 charliePk;
 
     function prepareAddresses() internal virtual {
         (deployer,) = deriveRememberKey(mnemonic, 0);
-        (bob,) = deriveRememberKey(mnemonic, 1);
+        (bob, bobPk) = deriveRememberKey(mnemonic, 1);
         (alice, alicePk) = deriveRememberKey(mnemonic, 2);
         (charlie, charliePk) = deriveRememberKey(mnemonic, 3);
         (anyone,) = deriveRememberKey(mnemonic, 4);

--- a/script/prod/RolloutV23.sol
+++ b/script/prod/RolloutV23.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { IPNFT } from "../../src/IPNFT.sol";
+import { IPermissioner, TermsAcceptedPermissioner } from "../../src/Permissioner.sol";
+import { Synthesizer } from "../../src/Synthesizer.sol";
+import { StakedLockingCrowdSale } from "../../src/crowdsale/StakedLockingCrowdSale.sol";
+
+contract RolloutV23 is Script {
+    function run() public {
+        address mintpass = 0x0Ecff38F41EcD1E978f1443eD96c0C22497d73cB;
+        //address vestedDaoToken = 0x0
+        address moleculeDevMultisig = 0xCfA0F84660fB33bFd07C369E5491Ab02C449f71B;
+        vm.startBroadcast();
+        IPNFT ipnftImpl = new IPNFT();
+
+        IPNFT ipnft = IPNFT(address(new ERC1967Proxy(address(ipnftImpl), "")));
+
+        ipnft.initialize();
+        ipnft.setAuthorizer(mintpass);
+        ipnft.transferOwnership(moleculeDevMultisig);
+
+        IPermissioner permissioner = new TermsAcceptedPermissioner();
+        Synthesizer synthImpl = new Synthesizer();
+
+        Synthesizer synthesizer = Synthesizer(
+            address(
+                new ERC1967Proxy(
+                    address(synthImpl), ""
+                )
+            )
+        );
+        synthesizer.initialize(ipnft, permissioner);
+        synthesizer.transferOwnership(moleculeDevMultisig);
+
+        StakedLockingCrowdSale stakedLockingCrowdSale = new StakedLockingCrowdSale();
+        //if we have vesting contracts:
+        //stakedLockingCrowdSale.trustVestingContract(vestedDaoToken);
+        //will work after merging:
+        stakedLockingCrowdSale.transferOwnership(moleculeDevMultisig);
+
+        //tell the tokenvesting owner to then execute:
+        // TokenVesting vestedDaoToken = TokenVesting(vm.envAddress("VDAO_TOKEN_ADDRESS"));
+        // vestedDaoToken.grantRole(vestedDaoToken.ROLE_CREATE_SCHEDULE(), address(stakedLockingCrowdSale));
+        vm.stopBroadcast();
+
+        console.log("IPNFT_ADDRESS=%s", address(ipnft));
+        console.log("TERMS_ACCEPTED_PERMISSIONER_ADDRESS=%s", address(permissioner));
+        console.log("SYNTHESIZER_ADDRESS=%s", address(synthesizer));
+        console.log("STAKED_LOCKING_CROWDSALE_ADDRESS=%s", address(stakedLockingCrowdSale));
+
+        console.log("synthImpl implementation: %s", address(synthImpl));
+        console.log("ipnft implementation: %s", address(ipnftImpl));
+    }
+}

--- a/src/Molecules.sol
+++ b/src/Molecules.sol
@@ -110,7 +110,7 @@ contract Molecules is ERC20BurnableUpgradeable, OwnableUpgradeable {
                     string.concat(
                         '{"name": "Molecules of IPNFT #',
                         tokenId,
-                        '","description": "this token represents molecules of the underlying asset","decimals": 18,"external_url": "https://molecule.to","image": "",',
+                        '","description": "Molecules, derived from IP-NFTs, are ERC-20 tokens governing IP pools.","decimals": 18,"external_url": "https://molecule.to","image": "",',
                         props,
                         "}"
                     )

--- a/src/Permissioner.sol
+++ b/src/Permissioner.sol
@@ -60,13 +60,7 @@ contract TermsAcceptedPermissioner is IPermissioner {
         return SignatureChecker.isValidSignatureNow(signer, termsHash, signature);
     }
 
-    /**
-     * @notice this yields the message text that claimers must present as signed message to burn their molecules and claim shares
-     * @param tokenContract ISynthesizedToken
-     */
-    function specificTermsV1(Molecules tokenContract) public view returns (string memory) {
-        Metadata memory metadata = tokenContract.metadata();
-
+    function specificTermsV1(Metadata memory metadata) public view returns (string memory) {
         return string.concat(
             "As a molecule holder of IPNFT #",
             Strings.toString(metadata.ipnftId),
@@ -78,5 +72,13 @@ contract TermsAcceptedPermissioner is IPermissioner {
             "\n",
             "Version: 1"
         );
+    }
+
+    /**
+     * @notice this yields the message text that claimers must present as signed message to burn their molecules and claim shares
+     * @param tokenContract ISynthesizedToken
+     */
+    function specificTermsV1(Molecules tokenContract) public view returns (string memory) {
+        return (specificTermsV1(tokenContract.metadata()));
     }
 }

--- a/subgraph/abis/Synthesizer.json
+++ b/subgraph/abis/Synthesizer.json
@@ -152,6 +152,11 @@
         "internalType": "contract IPNFT",
         "name": "_ipnft",
         "type": "address"
+      },
+      {
+        "internalType": "contract IPermissioner",
+        "name": "_permissioner",
+        "type": "address"
       }
     ],
     "name": "initialize",
@@ -208,6 +213,11 @@
         "internalType": "string",
         "name": "agreementCid",
         "type": "string"
+      },
+      {
+        "internalType": "bytes",
+        "name": "signedAgreement",
+        "type": "bytes"
       }
     ],
     "name": "synthesizeIpnft",

--- a/subgraph/abis/TermsAcceptedPermissioner.json
+++ b/subgraph/abis/TermsAcceptedPermissioner.json
@@ -84,6 +84,42 @@
   {
     "inputs": [
       {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "ipnftId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "originalOwner",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "agreementCid",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct Metadata",
+        "name": "metadata",
+        "type": "tuple"
+      }
+    ],
+    "name": "specificTermsV1",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "contract Molecules",
         "name": "tokenContract",
         "type": "address"

--- a/subgraph/config/mainnet.js
+++ b/subgraph/config/mainnet.js
@@ -15,5 +15,13 @@ module.exports = {
   synthesizer: {
     address: '',
     startBlock: 0
+  },
+  stakedLockingCrowdSale: {
+    address: '',
+    startBlock: 0
+  },
+  termsAcceptedPermissioner: {
+    address: '',
+    startBlock: 0
   }
 }

--- a/test/IPNFT.t.js
+++ b/test/IPNFT.t.js
@@ -53,7 +53,7 @@ describe('IPNFT fundamentals and upgrades', function () {
     const Synth0 = await ethers.getContractFactory('Synthesizer')
     const synth0 = await upgrades.deployProxy(
       Synth0,
-      [hre.ethers.constants.AddressZero],
+      [hre.ethers.constants.AddressZero, hre.ethers.constants.AddressZero],
       { kind: 'uups' }
     )
 

--- a/test/SalesShareDistributor.t.sol
+++ b/test/SalesShareDistributor.t.sol
@@ -90,7 +90,7 @@ contract SalesShareDistributorTest is Test {
                 )
             )
         );
-        synthesizer.initialize(ipnft);
+        synthesizer.initialize(ipnft, blindPermissioner);
 
         distributor = SalesShareDistributor(
             address(
@@ -123,7 +123,7 @@ contract SalesShareDistributorTest is Test {
     function testCreateListingAndSell() public {
         vm.startPrank(originalOwner);
         //ipnft.setApprovalForAll(address(synthesizer), true);
-        Molecules tokenContract = synthesizer.synthesizeIpnft(1, 100_000, agreementCid);
+        Molecules tokenContract = synthesizer.synthesizeIpnft(1, 100_000, agreementCid, "");
         uint256 listingId = helpCreateListing(1_000_000 ether, address(tokenContract));
         vm.stopPrank();
 
@@ -148,7 +148,7 @@ contract SalesShareDistributorTest is Test {
     function testStartClaimingPhase() public {
         vm.startPrank(originalOwner);
         // ipnft.setApprovalForAll(address(synthesizer), true);
-        Molecules tokenContract = synthesizer.synthesizeIpnft(1, 100_000, agreementCid);
+        Molecules tokenContract = synthesizer.synthesizeIpnft(1, 100_000, agreementCid, "");
 
         uint256 listingId = helpCreateListing(1_000_000 ether, address(distributor));
         vm.stopPrank();
@@ -180,7 +180,7 @@ contract SalesShareDistributorTest is Test {
 
     function testManuallyStartClaimingPhase() public {
         vm.startPrank(originalOwner);
-        Molecules tokenContract = synthesizer.synthesizeIpnft(1, 100_000, agreementCid);
+        Molecules tokenContract = synthesizer.synthesizeIpnft(1, 100_000, agreementCid, "");
         ipnft.safeTransferFrom(originalOwner, ipnftBuyer, 1);
         assertEq(tokenContract.issuer(), originalOwner);
         tokenContract.cap();
@@ -211,7 +211,7 @@ contract SalesShareDistributorTest is Test {
 
     function testClaimBuyoutShares() public {
         vm.startPrank(originalOwner);
-        Molecules tokenContract = synthesizer.synthesizeIpnft(1, 100_000, agreementCid);
+        Molecules tokenContract = synthesizer.synthesizeIpnft(1, 100_000, agreementCid, "");
         tokenContract.cap();
 
         TermsAcceptedPermissioner permissioner = new TermsAcceptedPermissioner();
@@ -280,7 +280,7 @@ contract SalesShareDistributorTest is Test {
 
     function testClaimBuyoutSharesAfterSwap() public {
         vm.startPrank(originalOwner);
-        Molecules tokenContract = synthesizer.synthesizeIpnft(1, 100_000, agreementCid);
+        Molecules tokenContract = synthesizer.synthesizeIpnft(1, 100_000, agreementCid, "");
         tokenContract.cap();
 
         uint256 listingId = helpCreateListing(1_000_000 ether, address(distributor));
@@ -325,7 +325,7 @@ contract SalesShareDistributorTest is Test {
         vm.assume(salesPrice <= 100_000_000_000 ether);
 
         vm.startPrank(originalOwner);
-        Molecules tokenContract = synthesizer.synthesizeIpnft(1, moleculesAmount, agreementCid);
+        Molecules tokenContract = synthesizer.synthesizeIpnft(1, moleculesAmount, agreementCid, "");
         tokenContract.cap();
 
         assertEq(tokenContract.balanceOf(originalOwner), moleculesAmount);
@@ -345,7 +345,7 @@ contract SalesShareDistributorTest is Test {
 
     function testClaimingFraud() public {
         vm.startPrank(originalOwner);
-        Molecules tokenContract1 = synthesizer.synthesizeIpnft(1, 100_000, agreementCid);
+        Molecules tokenContract1 = synthesizer.synthesizeIpnft(1, 100_000, agreementCid, "");
         tokenContract1.cap();
         ipnft.setApprovalForAll(address(schmackoSwap), true);
         uint256 listingId1 = schmackoSwap.list(IERC721(address(ipnft)), 1, erc20, 1000 ether, address(distributor));
@@ -362,7 +362,7 @@ contract SalesShareDistributorTest is Test {
         uint256 reservationId = ipnft.reserve();
         ipnft.mintReservation{ value: MINTING_FEE }(bob, reservationId, 2, ipfsUri, DEFAULT_SYMBOL);
         ipnft.setApprovalForAll(address(schmackoSwap), true);
-        Molecules tokenContract2 = synthesizer.synthesizeIpnft(2, 70_000, agreementCid);
+        Molecules tokenContract2 = synthesizer.synthesizeIpnft(2, 70_000, agreementCid, "");
         tokenContract2.cap();
         uint256 listingId2 = schmackoSwap.list(IERC721(address(ipnft)), 2, erc20, 700 ether, address(originalOwner));
         schmackoSwap.changeBuyerAllowance(listingId2, ipnftBuyer, true);


### PR DESCRIPTION
Synthesizer needs a permissioner by default
permissioner must accept presented signatures
permissioner based synth deployments
adds blind permissions to tests
permissioner can render terms without a token
deployed a blind permissioner based synth to görli