### PR TITLE
HUBS-90 adds metadata templates to the subgraph

### DIFF
--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -8,8 +8,8 @@
     "build:sepolia": "graph codegen && graph build --network sepolia",
     "build:mainnet": "graph codegen && graph build --network mainnet",
     "deploy:local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 moleculeprotocol/ipnft-subgraph",
-    "deploy:sepolia": "env-cmd -x -f ../.env graph deploy ip-nft-sepolia --version-label 1.2.0 --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
-    "deploy:mainnet": "env-cmd -x -f ../.env graph deploy ip-nft-mainnet --version-label 1.2.0 --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
+    "deploy:sepolia": "env-cmd -x -f ../.env graph deploy ip-nft-sepolia --version-label 1.2.1 --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
+    "deploy:mainnet": "env-cmd -x -f ../.env graph deploy ip-nft-mainnet --version-label 1.2.1 --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
     "create:local": "graph create --node http://localhost:8020/ moleculeprotocol/ipnft-subgraph",
     "remove:local": "graph remove --node http://localhost:8020/ moleculeprotocol/ipnft-subgraph",
     "test": "graph test"

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -7,6 +7,16 @@ type Ipnft @entity {
   listings: [Listing!] @derivedFrom(field: "ipnft")
   readers: [CanRead!] @derivedFrom(field: "ipnft")
   ipts: [IPT!] @derivedFrom(field: "ipnft")
+  metadata: IpnftMetadata
+  updatedAtTimestamp: BigInt
+}
+
+type IpnftMetadata @entity {
+  id: ID!
+  name: String!
+  image: String!
+  description: String!
+  externalURL: String!
 }
 
 type IPT @entity {

--- a/subgraph/src/ipnftMapping.ts
+++ b/subgraph/src/ipnftMapping.ts
@@ -75,19 +75,17 @@ export function handleReservation(event: ReservedEvent): void {
   reservation.save()
 }
 
-function updateIpnftMetadata(ipnft: Ipnft, uri: string, timestamp: BigInt): Ipnft {
+function updateIpnftMetadata(ipnft: Ipnft, uri: string, timestamp: BigInt): void {
     let ipfsLocation = uri.replace('ipfs://', '');
     if (!ipfsLocation || ipfsLocation == uri) {
-      log.error("Invalid URI format for tokenId {}: {}", [ipnft.id, uri]);
-      return ipnft;
+      log.error("Invalid URI format for tokenId {}: {}", [ipnft.id, uri])
+      return
     }
 
-    ipnft.tokenURI = uri;
-    ipnft.metadata = ipfsLocation;
-    ipnft.updatedAtTimestamp = timestamp;
-    IpnftMetadataTemplate.create(ipfsLocation);
-
-    return ipnft;
+    ipnft.tokenURI = uri
+    ipnft.metadata = ipfsLocation
+    ipnft.updatedAtTimestamp = timestamp
+    IpnftMetadataTemplate.create(ipfsLocation)
 }
 
 //the underlying parameter arrays are misaligned, hence we cannot cast or unify both events
@@ -96,7 +94,7 @@ export function handleMint(event: IPNFTMintedEvent): void {
   ipnft.owner = event.params.owner
   ipnft.createdAt = event.block.timestamp
   ipnft.symbol = event.params.symbol
-  ipnft = updateIpnftMetadata(ipnft, event.params.tokenURI, event.block.timestamp)
+  updateIpnftMetadata(ipnft, event.params.tokenURI, event.block.timestamp)
   store.remove('Reservation', event.params.tokenId.toString())
   ipnft.save()
 
@@ -116,7 +114,7 @@ export function handleMetadataUpdated(event: MetadataUpdateEvent): void {
     log.debug("no new uri found for token, likely just minted {}", [event.params._tokenId.toString()])
     return 
   }
-  ipnft = updateIpnftMetadata(ipnft, newUri, event.block.timestamp)  
+  updateIpnftMetadata(ipnft, newUri, event.block.timestamp)  
   ipnft.save()
 }
 

--- a/subgraph/src/metadataMapping.ts
+++ b/subgraph/src/metadataMapping.ts
@@ -1,0 +1,22 @@
+import { json, Bytes, dataSource } from '@graphprotocol/graph-ts'
+import { IpnftMetadata } from '../generated/schema'
+
+export function handleMetadata(content: Bytes): void {
+  let ipnftMetadata = new IpnftMetadata(dataSource.stringParam())
+  const value = json.fromBytes(content).toObject()
+  if (value) {
+    const image = value.get('image')
+    const name = value.get('name')
+    const description = value.get('description')
+    const externalURL = value.get('external_url')
+
+    if (name && image && description && externalURL) {
+      ipnftMetadata.name = name.toString()
+      ipnftMetadata.image = image.toString()
+      ipnftMetadata.externalURL = externalURL.toString()
+      ipnftMetadata.description = description.toString()
+    }
+
+    ipnftMetadata.save()
+  }
+}

--- a/subgraph/src/metadataMapping.ts
+++ b/subgraph/src/metadataMapping.ts
@@ -2,21 +2,21 @@ import { json, Bytes, dataSource } from '@graphprotocol/graph-ts'
 import { IpnftMetadata } from '../generated/schema'
 
 export function handleMetadata(content: Bytes): void {
-  let ipnftMetadata = new IpnftMetadata(dataSource.stringParam())
   const value = json.fromBytes(content).toObject()
   if (value) {
     const image = value.get('image')
     const name = value.get('name')
     const description = value.get('description')
     const externalURL = value.get('external_url')
-
+    
     if (name && image && description && externalURL) {
+      let ipnftMetadata = new IpnftMetadata(dataSource.stringParam())
       ipnftMetadata.name = name.toString()
       ipnftMetadata.image = image.toString()
       ipnftMetadata.externalURL = externalURL.toString()
       ipnftMetadata.description = description.toString()
+      ipnftMetadata.save()
     }
 
-    ipnftMetadata.save()
   }
 }

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -228,3 +228,16 @@ templates:
           handler: handleScheduled
         - event: ScheduleReleased(indexed bytes32,indexed address,uint256)
           handler: handleReleased
+  - name: IpnftMetadata
+    kind: file/ipfs
+    mapping:
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      file: ./src/metadataMapping.ts
+      handler: handleMetadata
+      entities:
+        - IpnftMetadata
+      abis:
+        - name: IPNFT
+          file: ./abis/IPNFT.json
+    network: foundry


### PR DESCRIPTION
this doesn't exactly work as expected but also doesn't really break sth :)

https://linear.app/molecule-to/issue/HUBS-90/read-ipnft-ipfs-metadata-during-subgraph-indexing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new fields in the IPNFT schema for enhanced metadata representation.
	- Added a new data source for IPNFT metadata to improve handling and storage.
	- Implemented new functions for processing IPNFT metadata and event handling.

- **Bug Fixes**
	- Updated deployment scripts to ensure correct version labeling for Sepolia and Mainnet networks.

- **Documentation**
	- Enhanced clarity in the GraphQL schema with new types and fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->