### PR TITLE
HUBS-124 adds more relevant ipnft metadata fields to the subgraph

### DIFF
--- a/deploy/inittest.sh
+++ b/deploy/inittest.sh
@@ -15,13 +15,13 @@ $DC ps
 ./setupLocal.sh -fx
 
 cd subgraph
-yarn codegen
-yarn build:local
-yarn create:local
+pnpm codegen
+pnpm build:local
+pnpm create:local
 # that's a bad local config hack still required: the root's subgraph.yaml's network must be "mainnet" for foundry
 sed -i '' -e 's/network\: foundry/network\: mainnet/g' build/subgraph.yaml
 sed -i '' -e 's/network\: foundry/network\: mainnet/g' subgraph.yaml
-yarn deploy:local -l v0.0.1
+pnpm deploy:local -l v0.0.1
 sed -i '' -e 's/network\: mainnet/network\: foundry/g' subgraph.yaml
 cd ..
 

--- a/deploy/inittest.sh
+++ b/deploy/inittest.sh
@@ -15,13 +15,13 @@ $DC ps
 ./setupLocal.sh -fx
 
 cd subgraph
-pnpm codegen
-pnpm build:local
-pnpm create:local
+yarn codegen
+yarn build:local
+yarn create:local
 # that's a bad local config hack still required: the root's subgraph.yaml's network must be "mainnet" for foundry
 sed -i '' -e 's/network\: foundry/network\: mainnet/g' build/subgraph.yaml
 sed -i '' -e 's/network\: foundry/network\: mainnet/g' subgraph.yaml
-pnpm deploy:local -l v0.0.1
+yarn deploy:local -l v0.0.1
 sed -i '' -e 's/network\: mainnet/network\: foundry/g' subgraph.yaml
 cd ..
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       GRAPH_LOG: debug
       GRAPH_ALLOW_NON_DETERMINISTIC_IPFS: 1
   ipfs:
-    image: ipfs/kubo:v0.30.0
+    image: ipfs/kubo:master-2025-01-15-1768204
     ports:
       - '5001:5001'
       - '8080:8080'

--- a/subgraph/.gitignore
+++ b/subgraph/.gitignore
@@ -2,3 +2,6 @@ node_modules
 
 build/
 generated
+
+tests/.bin
+.latest.json

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -8,8 +8,8 @@
     "build:sepolia": "graph codegen && graph build --network sepolia",
     "build:mainnet": "graph codegen && graph build --network mainnet",
     "deploy:local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 moleculeprotocol/ipnft-subgraph",
-    "deploy:sepolia": "env-cmd -x -f ../.env graph deploy ip-nft-sepolia --version-label 1.3.1-dev.8 --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
-    "deploy:mainnet": "env-cmd -x -f ../.env graph deploy ip-nft-mainnet --version-label 1.3.0 --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
+    "deploy:sepolia": "env-cmd -x -f ../.env graph deploy ip-nft-sepolia --version-label 1.3.1 --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
+    "deploy:mainnet": "env-cmd -x -f ../.env graph deploy ip-nft-mainnet --version-label 1.3.1 --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
     "create:local": "graph create --node http://localhost:8020/ moleculeprotocol/ipnft-subgraph",
     "remove:local": "graph remove --node http://localhost:8020/ moleculeprotocol/ipnft-subgraph",
     "test": "graph test"

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -8,7 +8,7 @@
     "build:sepolia": "graph codegen && graph build --network sepolia",
     "build:mainnet": "graph codegen && graph build --network mainnet",
     "deploy:local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 moleculeprotocol/ipnft-subgraph",
-    "deploy:sepolia": "env-cmd -x -f ../.env graph deploy ip-nft-sepolia --version-label 1.3.0 --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
+    "deploy:sepolia": "env-cmd -x -f ../.env graph deploy ip-nft-sepolia --version-label 1.3.1-dev.1 --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
     "deploy:mainnet": "env-cmd -x -f ../.env graph deploy ip-nft-mainnet --version-label 1.3.0 --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
     "create:local": "graph create --node http://localhost:8020/ moleculeprotocol/ipnft-subgraph",
     "remove:local": "graph remove --node http://localhost:8020/ moleculeprotocol/ipnft-subgraph",

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -8,7 +8,7 @@
     "build:sepolia": "graph codegen && graph build --network sepolia",
     "build:mainnet": "graph codegen && graph build --network mainnet",
     "deploy:local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 moleculeprotocol/ipnft-subgraph",
-    "deploy:sepolia": "env-cmd -x -f ../.env graph deploy ip-nft-sepolia --version-label 1.3.1-dev.1 --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
+    "deploy:sepolia": "env-cmd -x -f ../.env graph deploy ip-nft-sepolia --version-label 1.3.1-dev.8 --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
     "deploy:mainnet": "env-cmd -x -f ../.env graph deploy ip-nft-mainnet --version-label 1.3.0 --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
     "create:local": "graph create --node http://localhost:8020/ moleculeprotocol/ipnft-subgraph",
     "remove:local": "graph remove --node http://localhost:8020/ moleculeprotocol/ipnft-subgraph",

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -9,6 +9,9 @@ type Ipnft @entity {
   ipts: [IPT!] @derivedFrom(field: "ipnft")
   metadata: IpnftMetadata
   updatedAtTimestamp: BigInt
+
+  # as of 1.3 the Tokenizer only will create 1 ipt instance, in contrast to the ipts field above.
+  ipToken: Bytes 
 }
 
 type IpnftMetadata @entity {
@@ -17,17 +20,18 @@ type IpnftMetadata @entity {
   image: String!
   description: String!
   externalURL: String!
-  initialSymbol: String!
-  organization: String!
-  topic: String!
+
+  initialSymbol: String
+  organization: String
+  topic: String
 
   researchLead_name: String
   researchLead_email: String
   
-  fundingAmount_value: Int!
-  fundingAmount_decimals: Int8!
-  fundingAmount_currency: String!
-  fundingAmount_currencyType: String!
+  fundingAmount_value: String
+  fundingAmount_decimals: Int8
+  fundingAmount_currency: String
+  fundingAmount_currencyType: String
 }
 
 

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -17,6 +17,22 @@ type IpnftMetadata @entity {
   image: String!
   description: String!
   externalURL: String!
+  initialSymbol: String!
+  projectDetails: IpnftProjectDetails!
+}
+
+type IpnftProjectDetails @entity {
+  id: ID! # pd-metadataId
+  organization: String!
+  topic: String!
+
+  researchLead_name: String
+  researchLead_email: String
+  
+  fundingAmount_value: Int!
+  fundingAmount_decimals: Int8!
+  fundingAmount_currency: String!
+  fundingAmount_currencyType: String!
 }
 
 type IPT @entity {

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -18,11 +18,6 @@ type IpnftMetadata @entity {
   description: String!
   externalURL: String!
   initialSymbol: String!
-  projectDetails: IpnftProjectDetails!
-}
-
-type IpnftProjectDetails @entity {
-  id: ID! # pd-metadataId
   organization: String!
   topic: String!
 
@@ -34,6 +29,7 @@ type IpnftProjectDetails @entity {
   fundingAmount_currency: String!
   fundingAmount_currencyType: String!
 }
+
 
 type IPT @entity {
   id: ID! # ipt address

--- a/subgraph/src/ipnftMapping.ts
+++ b/subgraph/src/ipnftMapping.ts
@@ -106,7 +106,7 @@ export function handleMint(event: IPNFTMintedEvent): void {
 export function handleMetadataUpdated(event: MetadataUpdateEvent): void {
   let ipnft = Ipnft.load(event.params._tokenId.toString())
   if (!ipnft) {
-    log.error('ipnft {} not found', [event.params._tokenId.toString()])
+    log.error('[handleMetadataUpdated] ipnft {} not found', [event.params._tokenId.toString()])
     return
   }
 
@@ -114,7 +114,7 @@ export function handleMetadataUpdated(event: MetadataUpdateEvent): void {
   let _ipnftContract = IPNFTContract.bind(event.params._event.address)
   let newUri = _ipnftContract.tokenURI(event.params._tokenId)
   if (!newUri || newUri == '') {
-    log.debug('no new uri found for token, likely just minted {}', [
+    log.debug('[handleMetadataUpdated] no new uri found for token, likely just minted {}', [
       event.params._tokenId.toString()
     ])
     return

--- a/subgraph/src/metadataMapping.ts
+++ b/subgraph/src/metadataMapping.ts
@@ -1,5 +1,5 @@
-import { json, Bytes, dataSource } from '@graphprotocol/graph-ts'
-import { IpnftMetadata } from '../generated/schema'
+import { json, Bytes, dataSource,  } from '@graphprotocol/graph-ts'
+import { IpnftMetadata, IpnftProjectDetails } from '../generated/schema'
 
 export function handleMetadata(content: Bytes): void {
   const value = json.fromBytes(content).toObject()
@@ -15,6 +15,65 @@ export function handleMetadata(content: Bytes): void {
       ipnftMetadata.image = image.toString()
       ipnftMetadata.externalURL = externalURL.toString()
       ipnftMetadata.description = description.toString()
+  
+   
+      const _properties = value.get('properties')
+      if (_properties) {
+        const properties = _properties.toObject()
+        const initial_symbol = properties.get('initial_symbol')
+        if (initial_symbol) {
+          ipnftMetadata.initialSymbol = initial_symbol.toString()
+        }
+
+        let details = new IpnftProjectDetails("pd-"+ dataSource.stringParam())
+        const _project_details = properties.get('project_details')
+
+        if (_project_details) {
+          let projectDetails = _project_details.toObject()
+
+          let _organization = projectDetails.get('organization')
+          if (_organization) {
+            details.organization = _organization.toString()
+          }
+
+          let _topic = projectDetails.get('topic')
+          if (_topic) {
+            details.topic = _topic.toString()
+          }
+
+          let _research_lead = projectDetails.get('research_lead')
+
+          if (_research_lead) {
+            let researchLead = _research_lead.toObject()
+            let researchLead_email = researchLead.get('email')
+            let researchLead_name = researchLead.get('name')
+            
+            if (researchLead_email && researchLead_name) {
+              details.researchLead_email = researchLead_email.toString()
+              details.researchLead_name = researchLead_name.toString()
+            }
+          }
+
+          let _funding_amount = properties.get('funding_amount')
+          if (_funding_amount) {
+            let funding_amount = _funding_amount.toObject()
+            let _fundingAmount_value = funding_amount.get('value')
+            let _fundingAmount_decimals = funding_amount.get('decimals')
+            let _fundingAmount_currency = funding_amount.get('currency')
+            let _fundingAmount_currencyType = funding_amount.get('currency_type')
+            
+            if (_fundingAmount_value && _fundingAmount_decimals && _fundingAmount_currency && _fundingAmount_currencyType) {
+              details.fundingAmount_value = i32(_fundingAmount_value.toI64())
+              details.fundingAmount_decimals = i8(_fundingAmount_decimals.toI64())
+              details.fundingAmount_currency = _fundingAmount_currency.toString()
+              details.fundingAmount_currencyType = _fundingAmount_currencyType.toString()
+            }
+          }
+        }
+        details.save()
+        ipnftMetadata.projectDetails = details.id
+      }
+
       ipnftMetadata.save()
     }
 

--- a/subgraph/src/metadataMapping.ts
+++ b/subgraph/src/metadataMapping.ts
@@ -1,5 +1,5 @@
 import { json, Bytes, dataSource,  } from '@graphprotocol/graph-ts'
-import { IpnftMetadata, IpnftProjectDetails } from '../generated/schema'
+import { IpnftMetadata } from '../generated/schema'
 
 export function handleMetadata(content: Bytes): void {
   const value = json.fromBytes(content).toObject()
@@ -25,7 +25,6 @@ export function handleMetadata(content: Bytes): void {
           ipnftMetadata.initialSymbol = initial_symbol.toString()
         }
 
-        let details = new IpnftProjectDetails("pd-"+ dataSource.stringParam())
         const _project_details = properties.get('project_details')
 
         if (_project_details) {
@@ -33,12 +32,12 @@ export function handleMetadata(content: Bytes): void {
 
           let _organization = projectDetails.get('organization')
           if (_organization) {
-            details.organization = _organization.toString()
+            ipnftMetadata.organization = _organization.toString()
           }
 
           let _topic = projectDetails.get('topic')
           if (_topic) {
-            details.topic = _topic.toString()
+            ipnftMetadata.topic = _topic.toString()
           }
 
           let _research_lead = projectDetails.get('research_lead')
@@ -49,8 +48,8 @@ export function handleMetadata(content: Bytes): void {
             let researchLead_name = researchLead.get('name')
             
             if (researchLead_email && researchLead_name) {
-              details.researchLead_email = researchLead_email.toString()
-              details.researchLead_name = researchLead_name.toString()
+              ipnftMetadata.researchLead_email = researchLead_email.toString()
+              ipnftMetadata.researchLead_name = researchLead_name.toString()
             }
           }
 
@@ -63,15 +62,13 @@ export function handleMetadata(content: Bytes): void {
             let _fundingAmount_currencyType = funding_amount.get('currency_type')
             
             if (_fundingAmount_value && _fundingAmount_decimals && _fundingAmount_currency && _fundingAmount_currencyType) {
-              details.fundingAmount_value = i32(_fundingAmount_value.toI64())
-              details.fundingAmount_decimals = i8(_fundingAmount_decimals.toI64())
-              details.fundingAmount_currency = _fundingAmount_currency.toString()
-              details.fundingAmount_currencyType = _fundingAmount_currencyType.toString()
+              ipnftMetadata.fundingAmount_value = i32(_fundingAmount_value.toI64())
+              ipnftMetadata.fundingAmount_decimals = i8(_fundingAmount_decimals.toI64())
+              ipnftMetadata.fundingAmount_currency = _fundingAmount_currency.toString()
+              ipnftMetadata.fundingAmount_currencyType = _fundingAmount_currencyType.toString()
             }
           }
         }
-        details.save()
-        ipnftMetadata.projectDetails = details.id
       }
 
       ipnftMetadata.save()

--- a/subgraph/src/metadataMapping.ts
+++ b/subgraph/src/metadataMapping.ts
@@ -1,4 +1,4 @@
-import { json, Bytes, dataSource,  } from '@graphprotocol/graph-ts'
+import { json, Bytes, dataSource, log  } from '@graphprotocol/graph-ts'
 import { IpnftMetadata } from '../generated/schema'
 
 export function handleMetadata(content: Bytes): void {
@@ -9,70 +9,77 @@ export function handleMetadata(content: Bytes): void {
     const description = value.get('description')
     const externalURL = value.get('external_url')
     
+    let ipnftMetadata = new IpnftMetadata(dataSource.stringParam())
+    
     if (name && image && description && externalURL) {
-      let ipnftMetadata = new IpnftMetadata(dataSource.stringParam())
       ipnftMetadata.name = name.toString()
       ipnftMetadata.image = image.toString()
       ipnftMetadata.externalURL = externalURL.toString()
       ipnftMetadata.description = description.toString()
   
-   
-      const _properties = value.get('properties')
-      if (_properties) {
-        const properties = _properties.toObject()
-        const initial_symbol = properties.get('initial_symbol')
-        if (initial_symbol) {
-          ipnftMetadata.initialSymbol = initial_symbol.toString()
-        }
-
-        const _project_details = properties.get('project_details')
-
-        if (_project_details) {
-          let projectDetails = _project_details.toObject()
-
-          let _organization = projectDetails.get('organization')
-          if (_organization) {
-            ipnftMetadata.organization = _organization.toString()
-          }
-
-          let _topic = projectDetails.get('topic')
-          if (_topic) {
-            ipnftMetadata.topic = _topic.toString()
-          }
-
-          let _research_lead = projectDetails.get('research_lead')
-
-          if (_research_lead) {
-            let researchLead = _research_lead.toObject()
-            let researchLead_email = researchLead.get('email')
-            let researchLead_name = researchLead.get('name')
-            
-            if (researchLead_email && researchLead_name) {
-              ipnftMetadata.researchLead_email = researchLead_email.toString()
-              ipnftMetadata.researchLead_name = researchLead_name.toString()
-            }
-          }
-
-          let _funding_amount = properties.get('funding_amount')
-          if (_funding_amount) {
-            let funding_amount = _funding_amount.toObject()
-            let _fundingAmount_value = funding_amount.get('value')
-            let _fundingAmount_decimals = funding_amount.get('decimals')
-            let _fundingAmount_currency = funding_amount.get('currency')
-            let _fundingAmount_currencyType = funding_amount.get('currency_type')
-            
-            if (_fundingAmount_value && _fundingAmount_decimals && _fundingAmount_currency && _fundingAmount_currencyType) {
-              ipnftMetadata.fundingAmount_value = i32(_fundingAmount_value.toI64())
-              ipnftMetadata.fundingAmount_decimals = i8(_fundingAmount_decimals.toI64())
-              ipnftMetadata.fundingAmount_currency = _fundingAmount_currency.toString()
-              ipnftMetadata.fundingAmount_currencyType = _fundingAmount_currencyType.toString()
-            }
-          }
-        }
-      }
-
       ipnftMetadata.save()
+    } else {
+      log.info("[handlemetadata] name, image, description, external_url not found", [])
     }
 
+    let _properties = value.get('properties')
+    if (_properties) {
+      let properties = _properties.toObject()
+      let _initial_symbol = properties.get('initial_symbol')
+      if (_initial_symbol) {
+        ipnftMetadata.initialSymbol = _initial_symbol.toString()
+      } else {
+        ipnftMetadata.initialSymbol = ""
+        log.info("[handlemetadata] initial_symbol not found", [])
+      }
+
+      let _project_details = properties.get('project_details')
+
+      if (_project_details) {
+        let projectDetails = _project_details.toObject()
+
+        let _organization = projectDetails.get('organization')
+        if (_organization) {
+          ipnftMetadata.organization = _organization.toString()
+        }
+
+        let _topic = projectDetails.get('topic')
+        if (_topic) {
+          ipnftMetadata.topic = _topic.toString()
+        }
+
+        let _research_lead = projectDetails.get('research_lead')
+
+        if (_research_lead) {
+          let researchLead = _research_lead.toObject()
+          let researchLead_email = researchLead.get('email')
+          let researchLead_name = researchLead.get('name')
+          
+          if (researchLead_email && researchLead_name) {
+            ipnftMetadata.researchLead_email = researchLead_email.toString()
+            ipnftMetadata.researchLead_name = researchLead_name.toString()
+          }
+        }
+
+        let _funding_amount = properties.get('funding_amount')
+        if (_funding_amount) {
+          let funding_amount = _funding_amount.toObject()
+          let _fundingAmount_value = funding_amount.get('value')
+          let _fundingAmount_decimals = funding_amount.get('decimals')
+          let _fundingAmount_currency = funding_amount.get('currency')
+          let _fundingAmount_currencyType = funding_amount.get('currency_type')
+          
+          if (_fundingAmount_value && _fundingAmount_decimals && _fundingAmount_currency && _fundingAmount_currencyType) {
+            // on json metadata this can be a decimal value. I'm using a string to store as there's imo no f64 compatible decimal type on the schema scalar types
+            // https://thegraph.com/docs/en/subgraphs/developing/creating/ql-schema/#built-in-scalar-types
+            ipnftMetadata.fundingAmount_value = _fundingAmount_value.toF64().toString()
+            ipnftMetadata.fundingAmount_decimals = i8(_fundingAmount_decimals.toI64())
+            ipnftMetadata.fundingAmount_currency = _fundingAmount_currency.toString()
+            ipnftMetadata.fundingAmount_currencyType = _fundingAmount_currencyType.toString()
+          }
+        }
+      }      
+    }
+    ipnftMetadata.save()
   }
 }

--- a/subgraph/src/metadataMapping.ts
+++ b/subgraph/src/metadataMapping.ts
@@ -16,12 +16,12 @@ export function handleMetadata(content: Bytes): void {
       ipnftMetadata.image = image.toString()
       ipnftMetadata.externalURL = externalURL.toString()
       ipnftMetadata.description = description.toString()
-  
+      
       ipnftMetadata.save()
     } else {
       log.info("[handlemetadata] name, image, description, external_url not found", [])
     }
-
+    
     let _properties = value.get('properties')
     if (_properties) {
       let properties = _properties.toObject()
@@ -61,14 +61,15 @@ export function handleMetadata(content: Bytes): void {
           }
         }
 
-        let _funding_amount = properties.get('funding_amount')
+        let _funding_amount = projectDetails.get('funding_amount')
+        
         if (_funding_amount) {
           let funding_amount = _funding_amount.toObject()
           let _fundingAmount_value = funding_amount.get('value')
           let _fundingAmount_decimals = funding_amount.get('decimals')
           let _fundingAmount_currency = funding_amount.get('currency')
           let _fundingAmount_currencyType = funding_amount.get('currency_type')
-          
+
           if (_fundingAmount_value && _fundingAmount_decimals && _fundingAmount_currency && _fundingAmount_currencyType) {
             // on json metadata this can be a decimal value. I'm using a string to store as there's imo no f64 compatible decimal type on the schema scalar types
             // https://thegraph.com/docs/en/subgraphs/developing/creating/ql-schema/#built-in-scalar-types

--- a/subgraph/src/tokenizerMapping.ts
+++ b/subgraph/src/tokenizerMapping.ts
@@ -3,7 +3,7 @@ import { TokensCreated as TokensCreatedEvent } from '../generated/Tokenizer/Toke
 
 import { IPToken } from '../generated/templates'
 
-import { IPT } from '../generated/schema'
+import { IPT, Ipnft } from '../generated/schema'
 
 export function handleIPTsCreated(event: TokensCreatedEvent): void {
   let ipt = new IPT(event.params.tokenContract.toHexString())
@@ -23,4 +23,10 @@ export function handleIPTsCreated(event: TokensCreatedEvent): void {
   IPToken.create(event.params.tokenContract)
 
   ipt.save()
+
+  let ipnft = Ipnft.load(event.params.ipnftId.toString());
+  if (ipnft) {
+    ipnft.ipToken = event.params.tokenContract
+    ipnft.save()
+  }
 }

--- a/subgraph/tests/fixtures/ipnft_1.json
+++ b/subgraph/tests/fixtures/ipnft_1.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": "0.0.1",
+  "name": "Our awesome test IP-NFT",
+  "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua...",
+  "image": "ipfs://bafkreih5d2453qzkprn35zm4gj5ff6ezroevnaaygxqlwcbqq2tg7ebbe4",
+  "external_url": "https://testnet.mint.molecule.to/ipnft/76",
+  "terms_signature": "0x1f030b9f1a91d74610cb296aa87f12b2207d2b336766fffad8c53b825f1bee7d30f3665076102fe635dd3664d564ae1e5e746794b58e8861feafacfa6767ea491b",
+  "properties": {
+    "type": "IP-NFT",
+    "initial_symbol": "AWSOME",
+    "agreements": [
+      {
+        "type": "Research Agreement",
+        "url": "ipfs://bafkreigqttkfe2vsgddhy4ohf3qs3eyacdz2vwindo33y7jefox3377yqq",
+        "mime_type": "application/pdf",
+        "content_hash": "bagaaiera7ftqs3jmnoph3zgq67bgjrszlqtxkk5ygadgjvnihukrqioipndq",
+        "encryption": {
+          "protocol": "lit",
+          "encrypted_sym_key": "abcdefedcba0123443210",
+          "access_control_conditions": [
+            {
+              "conditionType": "evmContract",
+              "contractAddress": "0x152B444e60C526fe4434C721561a077269FcF61a",
+              "chain": "sepolia",
+              "functionName": "canRead",
+              "functionParams": [":userAddress", "76"],
+              "functionAbi": {
+                "inputs": [
+                  {
+                    "internalType": "address",
+                    "name": "reader",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "uint256",
+                    "name": "tokenId",
+                    "type": "uint256"
+                  }
+                ],
+                "name": "canRead",
+                "outputs": [
+                  {
+                    "internalType": "bool",
+                    "name": "",
+                    "type": "bool"
+                  }
+                ],
+                "stateMutability": "view",
+                "type": "function"
+              },
+              "returnValueTest": {
+                "key": "",
+                "comparator": "=",
+                "value": "true"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "type": "Assignment Agreement",
+        "url": "ipfs://bafkreihzm4ew2ldltz66juhxyjsmmwk4e52sxobqazsnlkb5cumcdsd3i4",
+        "mime_type": "application/pdf",
+        "content_hash": "bagaaiera7ftqs3jmnoph3zgq67bgjrszlqtxkk5ygadgjvnihukrqioipndq"
+      }
+    ],
+    "project_details": {
+      "industry": "Space Exploration",
+      "organization": "NASA",
+      "topic": "Wormholes",
+      "funding_amount": {
+        "value": 1234.5678,
+        "decimals": 2,
+        "currency": "USD",
+        "currency_type": "ISO4217"
+      },
+      "research_lead": {
+        "name": "Carl Sagan",
+        "email": "carl@example.com"
+      }
+    }
+  }
+}

--- a/subgraph/tests/metadata.test.ts
+++ b/subgraph/tests/metadata.test.ts
@@ -1,0 +1,28 @@
+import { ipfs } from "@graphprotocol/graph-ts"
+import { assert, describe, mockIpfsFile, test } from 'matchstick-as/assembly/index'
+import { handleMetadata } from '../src/metadataMapping'
+
+const IPNFT_METADATA = "IpnftMetadata"
+
+describe('Metadata', () => {
+    //https://thegraph.com/docs/en/subgraphs/developing/creating/unit-testing-framework/#mocking-ipfs-files-from-matchstick-041
+  
+    test('reads ipnft metadata', () => {
+  
+      mockIpfsFile('ipfsCatBaseIpnft', 'tests/fixtures/ipnft_1.json')
+      
+      let rawData = ipfs.cat("ipfsCatBaseIpnft")
+      if (!rawData) {
+        throw new Error("Failed to fetch ipfs data")
+      }
+      
+      handleMetadata(rawData)
+      assert.entityCount(IPNFT_METADATA, 1)
+      assert.fieldEquals(IPNFT_METADATA, '', 'topic', 'Wormholes')
+      assert.fieldEquals(IPNFT_METADATA, '', 'fundingAmount_value', '1234.5678')
+      assert.fieldEquals(IPNFT_METADATA, '', 'fundingAmount_currency', 'USD')
+
+      //logStore()
+    })
+})
+


### PR DESCRIPTION
extends the Subgraph with more IPNFT metadata. Please look at the matchstick test and notice the elegance how the graph allows you to test this case https://github.com/moleculeprotocol/IPNFT/pull/172/files#diff-e695976b80e70791b2ad0d0c0facbf1cbad3db6164e6f4c6f1b78e39a48012fc. Please be careful when just adopting this on the frontend: if you just trust this approach, the latency between minting & data appears on the subgraph will need to be handled. It's pretty nice to just query and display historic dat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes v1.3.1

- **New Features**
  - Enhanced IP-NFT metadata with additional fields including organization, topic, research lead details, and funding information
  - Improved token tracking with single IP token association

- **Bug Fixes**
  - Improved logging for metadata processing to aid debugging

- **Chores**
  - Updated IPFS service image to latest version
  - Bumped subgraph deployment version to 1.3.1

- **Tests**
  - Added comprehensive metadata handling test suite
<!-- end of auto-generated comment: release notes by coderabbit.ai -->