### PR TITLE
IP-1245-alchemy-subgraph-to-goldsky-move

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,6 @@ PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
 #optional:
 ALCHEMY_KEY=
-THEGRAPH_API_TOKEN=
-SATSUMA_DEPLOY_KEY=
 
 #these are deterministic when deployed in that order on a fresh node with hardhat (anvil) seed
 IPNFT_ADDRESS=0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,14 @@ PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 ALCHEMY_KEY=
 THEGRAPH_API_TOKEN=
 SATSUMA_DEPLOY_KEY=
+# You can find the IPFS hash by querying your Alchemy subgraph endpoint:
+# query {
+#   _meta {
+#     deployment
+#   }
+# }
+#
+IPFS_HASH=
 
 #these are deterministic when deployed in that order on a fresh node with hardhat (anvil) seed
 IPNFT_ADDRESS=0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512

--- a/.env.example
+++ b/.env.example
@@ -12,14 +12,6 @@ PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 ALCHEMY_KEY=
 THEGRAPH_API_TOKEN=
 SATSUMA_DEPLOY_KEY=
-# You can find the IPFS hash by querying your Alchemy subgraph endpoint:
-# query {
-#   _meta {
-#     deployment
-#   }
-# }
-#
-IPFS_HASH=
 
 #these are deterministic when deployed in that order on a fresh node with hardhat (anvil) seed
 IPNFT_ADDRESS=0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -8,8 +8,8 @@
     "build:sepolia": "graph codegen && graph build --network sepolia",
     "build:mainnet": "graph codegen && graph build --network mainnet",
     "deploy:local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 moleculeprotocol/ipnft-subgraph",
-    "deploy:sepolia": "env-cmd -x -f ../.env goldsky subgraph deploy ip-nft-sepolia/v1.3.2 --from-ipfs-hash \\$IPFS_HASH --ipfs-gateway https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
-    "deploy:mainnet": "env-cmd -x -f ../.env goldsky subgraph deploy ip-nft-mainnet/v1.3.2 --from-ipfs-hash \\$IPFS_HASH --ipfs-gateway https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
+    "deploy:sepolia": "env-cmd -x -f ../.env goldsky subgraph deploy ip-nft-sepolia/1.3.2 --from-ipfs-hash \\$IPFS_HASH --ipfs-gateway https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
+    "deploy:mainnet": "env-cmd -x -f ../.env goldsky subgraph deploy ip-nft-mainnet/1.3.2 --from-ipfs-hash \\$IPFS_HASH --ipfs-gateway https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
     "create:local": "graph create --node http://localhost:8020/ moleculeprotocol/ipnft-subgraph",
     "remove:local": "graph remove --node http://localhost:8020/ moleculeprotocol/ipnft-subgraph",
     "test": "graph test"

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -8,8 +8,8 @@
     "build:sepolia": "graph codegen && graph build --network sepolia",
     "build:mainnet": "graph codegen && graph build --network mainnet",
     "deploy:local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 moleculeprotocol/ipnft-subgraph",
-    "deploy:sepolia": "env-cmd -x -f ../.env graph deploy ip-nft-sepolia --version-label 1.3.2 --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
-    "deploy:mainnet": "env-cmd -x -f ../.env graph deploy ip-nft-mainnet --version-label 1.3.2 --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
+    "deploy:sepolia": "env-cmd -x -f ../.env goldsky subgraph deploy ip-nft-sepolia/v1.3.2 --from-ipfs-hash \\$IPFS_HASH --ipfs-gateway https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
+    "deploy:mainnet": "env-cmd -x -f ../.env goldsky subgraph deploy ip-nft-mainnet/v1.3.2 --from-ipfs-hash \\$IPFS_HASH --ipfs-gateway https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
     "create:local": "graph create --node http://localhost:8020/ moleculeprotocol/ipnft-subgraph",
     "remove:local": "graph remove --node http://localhost:8020/ moleculeprotocol/ipnft-subgraph",
     "test": "graph test"

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -8,8 +8,8 @@
     "build:sepolia": "graph codegen && graph build --network sepolia",
     "build:mainnet": "graph codegen && graph build --network mainnet",
     "deploy:local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 moleculeprotocol/ipnft-subgraph",
-    "deploy:sepolia": "env-cmd -x -f ../.env goldsky subgraph deploy ip-nft-sepolia/1.3.3 --from-ipfs-hash \\$IPFS_HASH --ipfs-gateway https://ipfs.satsuma.xyz",
-    "deploy:mainnet": "env-cmd -x -f ../.env goldsky subgraph deploy ip-nft-mainnet/1.3.3 --from-ipfs-hash \\$IPFS_HASH --ipfs-gateway https://ipfs.satsuma.xyz",
+    "deploy:sepolia": "env-cmd -x -f ../.env goldsky subgraph deploy ip-nft-sepolia/1.3.2 --ipfs-gateway https://ipfs.satsuma.xyz",
+    "deploy:mainnet": "env-cmd -x -f ../.env goldsky subgraph deploy ip-nft-mainnet/1.3.2 --ipfs-gateway https://ipfs.satsuma.xyz",
     "create:local": "graph create --node http://localhost:8020/ moleculeprotocol/ipnft-subgraph",
     "remove:local": "graph remove --node http://localhost:8020/ moleculeprotocol/ipnft-subgraph",
     "test": "graph test"

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -8,8 +8,8 @@
     "build:sepolia": "graph codegen && graph build --network sepolia",
     "build:mainnet": "graph codegen && graph build --network mainnet",
     "deploy:local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 moleculeprotocol/ipnft-subgraph",
-    "deploy:sepolia": "env-cmd -x -f ../.env goldsky subgraph deploy ip-nft-sepolia/1.3.2 --from-ipfs-hash \\$IPFS_HASH --ipfs-gateway https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
-    "deploy:mainnet": "env-cmd -x -f ../.env goldsky subgraph deploy ip-nft-mainnet/1.3.2 --from-ipfs-hash \\$IPFS_HASH --ipfs-gateway https://ipfs.satsuma.xyz --deploy-key \\$SATSUMA_DEPLOY_KEY",
+    "deploy:sepolia": "env-cmd -x -f ../.env goldsky subgraph deploy ip-nft-sepolia/1.3.3 --from-ipfs-hash \\$IPFS_HASH --ipfs-gateway https://ipfs.satsuma.xyz",
+    "deploy:mainnet": "env-cmd -x -f ../.env goldsky subgraph deploy ip-nft-mainnet/1.3.3 --from-ipfs-hash \\$IPFS_HASH --ipfs-gateway https://ipfs.satsuma.xyz",
     "create:local": "graph create --node http://localhost:8020/ moleculeprotocol/ipnft-subgraph",
     "remove:local": "graph remove --node http://localhost:8020/ moleculeprotocol/ipnft-subgraph",
     "test": "graph test"

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -8,8 +8,8 @@
     "build:sepolia": "graph codegen && graph build --network sepolia",
     "build:mainnet": "graph codegen && graph build --network mainnet",
     "deploy:local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 moleculeprotocol/ipnft-subgraph",
-    "deploy:sepolia": "env-cmd -x -f ../.env goldsky subgraph deploy ip-nft-sepolia/1.3.2 --ipfs-gateway https://ipfs.satsuma.xyz",
-    "deploy:mainnet": "env-cmd -x -f ../.env goldsky subgraph deploy ip-nft-mainnet/1.3.2 --ipfs-gateway https://ipfs.satsuma.xyz",
+    "deploy:sepolia": "goldsky subgraph deploy ip-nft-sepolia/1.3.2 --ipfs-gateway https://ipfs.satsuma.xyz",
+    "deploy:mainnet": "goldsky subgraph deploy ip-nft-mainnet/1.3.2 --ipfs-gateway https://ipfs.satsuma.xyz",
     "create:local": "graph create --node http://localhost:8020/ moleculeprotocol/ipnft-subgraph",
     "remove:local": "graph remove --node http://localhost:8020/ moleculeprotocol/ipnft-subgraph",
     "test": "graph test"
@@ -19,8 +19,5 @@
     "@graphprotocol/graph-ts": "^0.35.1",
     "dotenv": "^16.0.3",
     "matchstick-as": "0.5.2"
-  },
-  "devDependencies": {
-    "env-cmd": "^10.1.0"
   }
 }

--- a/subgraph/yarn.lock
+++ b/subgraph/yarn.lock
@@ -1182,11 +1182,6 @@ commander@^2.20.3:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
-  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1246,7 +1241,7 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.3:
+cross-spawn@7.0.3, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -1413,14 +1408,6 @@ enquirer@2.3.6:
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
   dependencies:
     ansi-colors "^4.1.1"
-
-env-cmd@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/env-cmd/-/env-cmd-10.1.0.tgz#c7f5d3b550c9519f137fdac4dd8fb6866a8c8c4b"
-  integrity sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==
-  dependencies:
-    commander "^4.0.0"
-    cross-spawn "^7.0.0"
 
 err-code@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
https://linear.app/molecule-to/issue/IP-1245/be-alchemy-subgraphs-are-getting-deprecated-on-dec-8-2025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched Sepolia and Mainnet deployment workflow to a Goldsky-based flow.
  * Deployment commands now accept IPFS-based package identifiers and support specifying an IPFS gateway.
  * Adopted explicit versioning for release deployments and simplified the deployment pipeline.
  * Removed two environment variables from the example environment file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->